### PR TITLE
style: unify the SQL table creation statements

### DIFF
--- a/db/migrations/1_init.up.sql
+++ b/db/migrations/1_init.up.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS "attempts" (
     "id"             CHAR(27) PRIMARY KEY,
     "event_id"       CHAR(27) REFERENCES "events" ("id") ON DELETE CASCADE,
     "endpoint_id"    CHAR(27) REFERENCES "endpoints" ("id") ON DELETE CASCADE,
-    "status"         varCHAR(20) not null,
+    "status"         VARCHAR(20) not null,
 
     "attempt_number" SMALLINT    NOT NULL DEFAULT 1,
     "scheduled_at"   TIMESTAMPTZ(3),

--- a/db/migrations/1_init.up.sql
+++ b/db/migrations/1_init.up.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS "attempts" (
     "id"             CHAR(27) PRIMARY KEY,
     "event_id"       CHAR(27) REFERENCES "events" ("id") ON DELETE CASCADE,
     "endpoint_id"    CHAR(27) REFERENCES "endpoints" ("id") ON DELETE CASCADE,
-    "status"         VARCHAR(20) not null,
+    "status"         VARCHAR(20) NOT NULL,
 
     "attempt_number" SMALLINT    NOT NULL DEFAULT 1,
     "scheduled_at"   TIMESTAMPTZ(3),

--- a/db/migrations/1_init.up.sql
+++ b/db/migrations/1_init.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS "workspaces" (
-    "id"          char(27) PRIMARY KEY,
+    "id"          CHAR(27) PRIMARY KEY,
     "name"        TEXT UNIQUE,
     "description" TEXT,
 
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS "workspaces" (
 );
 
 CREATE TABLE IF NOT EXISTS "endpoints" (
-    "id"          char(27) PRIMARY KEY,
+    "id"          CHAR(27) PRIMARY KEY,
     "name"        TEXT,
     "description" TEXT,
     "request"     JSONB   NOT NULL DEFAULT '{}'::jsonb,
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS "endpoints" (
     "events"      TEXT[],
     "retry"       JSONB   NOT NULL DEFAULT '{}'::jsonb,
 
-    "ws_id"       char(27),
+    "ws_id"       CHAR(27),
     "created_at"  TIMESTAMPTZ(3)      DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'),
     "updated_at"  TIMESTAMPTZ(3)      DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC')
 );
@@ -26,11 +26,11 @@ CREATE INDEX idx_endpoints_ws_id ON endpoints (ws_id);
 CREATE UNIQUE INDEX uk_endpoints_ws_name ON endpoints (ws_id, name);
 
 CREATE TABLE IF NOT EXISTS "events" (
-    "id"         char(27) PRIMARY KEY,
+    "id"         CHAR(27) PRIMARY KEY,
     "data"       JSONB NOT NULL,
     "event_type" TEXT  NOT NULL,
 
-    "ws_id"      char(27),
+    "ws_id"      CHAR(27),
     "created_at" TIMESTAMPTZ(3) DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'),
     "updated_at" TIMESTAMPTZ(3) DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC')
 );
@@ -38,10 +38,10 @@ CREATE TABLE IF NOT EXISTS "events" (
 CREATE INDEX idx_events_ws_id ON events (ws_id);
 
 CREATE TABLE IF NOT EXISTS "attempts" (
-    "id"             char(27) PRIMARY KEY,
-    "event_id"       char(27) REFERENCES "events" ("id") ON DELETE CASCADE,
-    "endpoint_id"    char(27) REFERENCES "endpoints" ("id") ON DELETE CASCADE,
-    "status"         varchar(20) not null,
+    "id"             CHAR(27) PRIMARY KEY,
+    "event_id"       CHAR(27) REFERENCES "events" ("id") ON DELETE CASCADE,
+    "endpoint_id"    CHAR(27) REFERENCES "endpoints" ("id") ON DELETE CASCADE,
+    "status"         varCHAR(20) not null,
 
     "attempt_number" SMALLINT    NOT NULL DEFAULT 1,
     "scheduled_at"   TIMESTAMPTZ(3),
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS "attempts" (
     "request"        JSONB,
     "response"       JSONB,
 
-    "ws_id"          char(27),
+    "ws_id"          CHAR(27),
     "created_at"     TIMESTAMPTZ(3)          DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'),
     "updated_at"     TIMESTAMPTZ(3)          DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC')
 );
@@ -62,7 +62,7 @@ CREATE INDEX idx_attempts_ws_id ON attempts (ws_id);
 CREATE INDEX idx_attempts_status ON attempts (status);
 
 CREATE TABLE IF NOT EXISTS "sources" (
-    "id"          char(27) PRIMARY KEY,
+    "id"          CHAR(27) PRIMARY KEY,
     "name"        TEXT UNIQUE,
     "enabled"     BOOLEAN NOT NULL DEFAULT true,
 
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS "sources" (
     "methods"     TEXT[],
     "response"    JSONB,
 
-    "ws_id"       char(27),
+    "ws_id"       CHAR(27),
     "created_at"  TIMESTAMPTZ(3) DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'),
     "updated_at"  TIMESTAMPTZ(3) DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC')
 );


### PR DESCRIPTION
### Changes

Update the `char` to `CHAR`, and `varchar` to `VARCHAR`  in SQL table creation statements to keep code style consistent. 

### Impact

No code logic change.