### PR TITLE
fix: keeping nested field structure for fields that failed to validate

### DIFF
--- a/pkg/errs/error.go
+++ b/pkg/errs/error.go
@@ -16,15 +16,15 @@ func (e *Error) Error() string {
 
 type ValidateError struct {
 	err     error
-	Message string            `json:"message"`
-	Fields  map[string]string `json:"fields"`
+	Message string                 `json:"message"`
+	Fields  map[string]interface{} `json:"fields"`
 }
 
 func NewValidateError(err error) *ValidateError {
 	return &ValidateError{
 		err:     err,
 		Message: err.Error(),
-		Fields:  make(map[string]string),
+		Fields:  make(map[string]interface{}),
 	}
 }
 

--- a/test/admin/endpoints_test.go
+++ b/test/admin/endpoints_test.go
@@ -87,7 +87,7 @@ var _ = Describe("/endpoints", Ordered, func() {
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 				assert.Equal(GinkgoT(),
-					`{"message":"Request Validation","error":{"message":"request validation","fields":{"method":"required field missing","url":"required field missing"}}}`,
+					`{"message":"Request Validation","error":{"message":"request validation","fields":{"request":{"method":"required field missing","url":"required field missing"}}}}`,
 					string(resp.Body()))
 			})
 		})

--- a/test/admin/endpoints_test.go
+++ b/test/admin/endpoints_test.go
@@ -87,7 +87,7 @@ var _ = Describe("/endpoints", Ordered, func() {
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 				assert.Equal(GinkgoT(),
-					`{"message":"Request Validation","error":{"message":"request validation","fields":{"method":"invalid method","url":"invalid url"}}}`,
+					`{"message":"Request Validation","error":{"message":"request validation","fields":{"method":"required field missing","url":"required field missing"}}}`,
 					string(resp.Body()))
 			})
 		})

--- a/utils/validate.go
+++ b/utils/validate.go
@@ -11,39 +11,71 @@ import (
 
 var validate = validator.New(validator.WithRequiredStructEnabled())
 
+var validationErr = errors.New("request validation")
+
 func Validate(v interface{}) error {
 	err := validate.Struct(v)
 	if err != nil {
-		validateErr := errs.NewValidateError(errors.New("request validation"))
+		validateErr := errs.NewValidateError(validationErr)
+		t := reflect.ValueOf(v).Type()
 		for _, e := range err.(validator.ValidationErrors) {
-			// todo nested fields
-			t := reflect.ValueOf(v).Type()
-			list := strings.Split(e.StructNamespace(), ".")
-			list = list[1:]
-			field := findField(t, list)
-			msg := fmt.Sprintf("invalid %s", field.Tag.Get("json"))
-			validateErr.Fields[field.Tag.Get("json")] = msg
+			fields := strings.Split(e.StructNamespace(), ".")
+			node := validateErr.Fields
+			parentT := t
+			for i := 1; i < len(fields); i++ {
+				f, ok := getField(parentT, fields[i])
+				if !ok {
+					continue
+				}
+
+				fieldName := fieldName(f)
+				if i < len(fields)-1 {
+					if node[fieldName] == nil {
+						node[fieldName] = make(map[string]interface{})
+					}
+					node = node[fieldName].(map[string]interface{})
+				} else {
+					node[fieldName] = formatError(e)
+				}
+				parentT = f.Type
+			}
 		}
 		return validateErr
 	}
 	return nil
 }
 
-func findField(s reflect.Type, path []string) *reflect.StructField {
-	var field reflect.StructField
-
-	t := s
-	for _, p := range path {
-		if t.Kind() == reflect.Ptr {
-			t = t.Elem()
-		}
-
-		f, ok := t.FieldByName(p)
-		if ok {
-			field = f
-			t = f.Type
-		}
+func formatError(fe validator.FieldError) string {
+	switch fe.Tag() {
+	case "required":
+		return "required field missing"
+	case "oneof":
+		return fmt.Sprintf("invalid value: %s", fe.Value())
+	case "gt":
+		return fmt.Sprintf("value must be > %s", fe.Param())
+	case "gte":
+		return fmt.Sprintf("value must be >= %s", fe.Param())
+	case "lt":
+		return fmt.Sprintf("value must be < %s", fe.Param())
+	case "lte":
+		return fmt.Sprintf("value must be <= %s", fe.Param())
+	case "min":
+		return fmt.Sprintf("length must be at least %s", fe.Param())
 	}
+	return fe.Error()
+}
 
-	return &field
+func fieldName(field reflect.StructField) string {
+	name := field.Tag.Get("json")
+	if name == "" {
+		name = field.Name
+	}
+	return name
+}
+
+func getField(t reflect.Type, field string) (reflect.StructField, bool) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.FieldByName(field)
 }

--- a/utils/validate_test.go
+++ b/utils/validate_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type NestB struct {
+	Timeout int `validate:"gt=0"`
+}
+
+type NestA struct {
+	Gender string `validate:"oneof=male female"`
+	NestB  NestB
+}
+
+type Struct struct {
+	ID   string `json:"id"`
+	Name string `validate:"required"`
+	Nest NestA
+	Age  int      `validate:"gte=0,lte=100"`
+	Pets []string `validate:"min=1"`
+}
+
+func TestValidate(t *testing.T) {
+	err := Validate(&Struct{
+		Name: "",
+		Nest: NestA{
+			Gender: "x",
+			NestB: NestB{
+				Timeout: 0,
+			},
+		},
+		Age:  -1,
+		Pets: nil,
+	})
+	bytes, err := json.MarshalIndent(err, "", "   ")
+	expected := `
+{
+   "message": "request validation",
+   "fields": {
+      "Age": "value must be >= 0",
+      "Name": "required field missing",
+      "Nest": {
+         "Gender": "invalid value: x",
+         "NestB": {
+            "Timeout": "value must be > 0"
+         }
+      },
+      "Pets": "length must be at least 1"
+   }
+}
+`
+	assert.JSONEq(t, expected, string(bytes))
+}

--- a/utils/validate_test.go
+++ b/utils/validate_test.go
@@ -35,7 +35,8 @@ func TestValidate(t *testing.T) {
 		Age:  -1,
 		Pets: nil,
 	})
-	bytes, err := json.MarshalIndent(err, "", "   ")
+	bytes, e := json.MarshalIndent(err, "", "   ")
+	assert.NoError(t, e)
 	expected := `
 {
    "message": "request validation",


### PR DESCRIPTION
Summary:

Keep the correct structure for nested fields. e.g.

```
{
   "message": "request validation",
   "fields": {
      "Age": "value must be >= 0",
      "Name": "required field missing",
      "Nest": {
         "Gender": "invalid value: x",
         "NestB": {
            "Timeout": "value must be > 0"
         }
      },
      "Pets": "length must be at least 1"
   }
}
```