### PR TITLE
feat(attempts): add AttemptDetail to store attempt's request and response information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ test-integration-coverage: clean
 goreleaser:
 	goreleaser release --snapshot --clean
 
-migrate-revision:
+migrate-create:
 	migrate create -ext sql -dir db/migrations -seq -digits 1 $(message)

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ test-integration-coverage: clean
 .PHONY: goreleaser
 goreleaser:
 	goreleaser release --snapshot --clean
+
+migrate-revision:
+	migrate create -ext sql -dir db/migrations -seq -digits 1 $(message)

--- a/admin/api/attempts.go
+++ b/admin/api/attempts.go
@@ -1,9 +1,10 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/webhookx-io/webhookx/db/query"
 	"github.com/webhookx-io/webhookx/utils"
-	"net/http"
 )
 
 func (api *API) PageAttempt(w http.ResponseWriter, r *http.Request) {
@@ -31,6 +32,10 @@ func (api *API) GetAttempt(w http.ResponseWriter, r *http.Request) {
 		api.json(404, w, ErrorResponse{Message: MsgNotFound})
 		return
 	}
+
+	attemptDetail, err := api.DB.AttemptDetailsWS.Get(r.Context(), attempt.ID)
+	api.assert(err)
+	attempt.Extend(attemptDetail)
 
 	api.json(200, w, attempt)
 }

--- a/admin/api/attempts.go
+++ b/admin/api/attempts.go
@@ -33,9 +33,11 @@ func (api *API) GetAttempt(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	attemptDetail, err := api.DB.AttemptDetailsWS.Get(r.Context(), attempt.ID)
-	api.assert(err)
-	attempt.Extend(attemptDetail)
+	if attempt.Delivered() {
+		attemptDetail, err := api.DB.AttemptDetailsWS.Get(r.Context(), attempt.ID)
+		api.assert(err)
+		attempt.Extend(attemptDetail)
+	}
 
 	api.json(200, w, attempt)
 }

--- a/db/dao/attempt_detail_dao.go
+++ b/db/dao/attempt_detail_dao.go
@@ -1,0 +1,35 @@
+package dao
+
+import (
+	"context"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/webhookx-io/webhookx/db/entities"
+)
+
+type attemptDetailDao struct {
+	*DAO[entities.AttemptDetail]
+}
+
+func NewAttemptDetailDao(db *sqlx.DB, workspace bool) AttemptDetailDAO {
+	return &attemptDetailDao{
+		DAO: NewDAO[entities.AttemptDetail]("attempt_details", db, workspace),
+	}
+}
+
+func (dao *attemptDetailDao) Upsert(ctx context.Context, attemptDetail *entities.AttemptDetail) error {
+	values := []interface{}{attemptDetail.ID, attemptDetail.RequestHeaders, attemptDetail.RequestBody, attemptDetail.ResponseHeaders, attemptDetail.ResponseBody, time.Now(), attemptDetail.WorkspaceId}
+
+	sql := `INSERT INTO attempt_details (id, request_headers, request_body, response_headers, response_body, updated_at, ws_id) VALUES ($1, $2, $3, $4, $5, $6, $7) 
+		ON CONFLICT (id) DO UPDATE SET 
+		request_headers = EXCLUDED.request_headers, 
+		request_body = EXCLUDED.request_body, 
+		response_headers = EXCLUDED.response_headers, 
+		response_body = EXCLUDED.response_body, 
+		updated_at = EXCLUDED.updated_at 
+		RETURNING *`
+
+	err := dao.UnsafeDB(ctx).QueryRowxContext(ctx, sql, values...).StructScan(attemptDetail)
+	return err
+}

--- a/db/dao/dao.go
+++ b/db/dao/dao.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"reflect"
+	"strings"
+	"time"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
 	"github.com/webhookx-io/webhookx/db/errs"
@@ -13,9 +17,6 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/ucontext"
 	"github.com/webhookx-io/webhookx/utils"
 	"go.uber.org/zap"
-	"reflect"
-	"strings"
-	"time"
 )
 
 var (

--- a/db/dao/daos.go
+++ b/db/dao/daos.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/db/query"
 )
@@ -39,4 +40,9 @@ type AttemptDAO interface {
 
 type SourceDAO interface {
 	BaseDAO[entities.Source]
+}
+
+type AttemptDetailDAO interface {
+	BaseDAO[entities.AttemptDetail]
+	Upsert(ctx context.Context, attemptDetail *entities.AttemptDetail) error
 }

--- a/db/db.go
+++ b/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"github.com/webhookx-io/webhookx/config"
@@ -15,23 +16,25 @@ type DB struct {
 	DB  *sqlx.DB
 	log *zap.SugaredLogger
 
-	Workspaces  dao.WorkspaceDAO
-	Endpoints   dao.EndpointDAO
-	EndpointsWS dao.EndpointDAO
-	Events      dao.EventDAO
-	EventsWS    dao.EventDAO
-	Attempts    dao.AttemptDAO
-	AttemptsWS  dao.AttemptDAO
-	Sources     dao.SourceDAO
-	SourcesWS   dao.SourceDAO
+	Workspaces       dao.WorkspaceDAO
+	Endpoints        dao.EndpointDAO
+	EndpointsWS      dao.EndpointDAO
+	Events           dao.EventDAO
+	EventsWS         dao.EventDAO
+	Attempts         dao.AttemptDAO
+	AttemptsWS       dao.AttemptDAO
+	Sources          dao.SourceDAO
+	SourcesWS        dao.SourceDAO
+	AttemptDetails   dao.AttemptDetailDAO
+	AttemptDetailsWS dao.AttemptDetailDAO
 }
 
 func initSqlxDB(cfg *config.DatabaseConfig) (*sqlx.DB, error) {
 	db, err := cfg.GetDB()
-	//db.SetMaxOpenConns(100)
-	//db.SetMaxIdleConns(100)
-	//db.SetConnMaxLifetime(time.Hour)
-	//db.SetConnMaxIdleTime(time.Hour)
+	// db.SetMaxOpenConns(100)
+	// db.SetMaxIdleConns(100)
+	// db.SetConnMaxLifetime(time.Hour)
+	// db.SetConnMaxIdleTime(time.Hour)
 	if err != nil {
 		return nil, err
 	}
@@ -45,17 +48,19 @@ func NewDB(cfg *config.DatabaseConfig) (*DB, error) {
 	}
 
 	db := &DB{
-		DB:          sqlxDB,
-		log:         zap.S(),
-		Workspaces:  dao.NewWorkspaceDAO(sqlxDB),
-		Endpoints:   dao.NewEndpointDAO(sqlxDB, false),
-		EndpointsWS: dao.NewEndpointDAO(sqlxDB, true),
-		Events:      dao.NewEventDao(sqlxDB, false),
-		EventsWS:    dao.NewEventDao(sqlxDB, true),
-		Attempts:    dao.NewAttemptDao(sqlxDB, false),
-		AttemptsWS:  dao.NewAttemptDao(sqlxDB, true),
-		Sources:     dao.NewSourceDAO(sqlxDB, false),
-		SourcesWS:   dao.NewSourceDAO(sqlxDB, true),
+		DB:               sqlxDB,
+		log:              zap.S(),
+		Workspaces:       dao.NewWorkspaceDAO(sqlxDB),
+		Endpoints:        dao.NewEndpointDAO(sqlxDB, false),
+		EndpointsWS:      dao.NewEndpointDAO(sqlxDB, true),
+		Events:           dao.NewEventDao(sqlxDB, false),
+		EventsWS:         dao.NewEventDao(sqlxDB, true),
+		Attempts:         dao.NewAttemptDao(sqlxDB, false),
+		AttemptsWS:       dao.NewAttemptDao(sqlxDB, true),
+		Sources:          dao.NewSourceDAO(sqlxDB, false),
+		SourcesWS:        dao.NewSourceDAO(sqlxDB, true),
+		AttemptDetails:   dao.NewAttemptDetailDao(sqlxDB, false),
+		AttemptDetailsWS: dao.NewAttemptDetailDao(sqlxDB, true),
 	}
 
 	return db, nil
@@ -84,7 +89,6 @@ func (db *DB) TX(ctx context.Context, fn func(ctx context.Context) error) error 
 	ctx = transaction.WithTx(ctx, tx)
 
 	err = fn(ctx)
-
 	if err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
 			return errors.Wrap(err, rbErr.Error())

--- a/db/entities/attempt.go
+++ b/db/entities/attempt.go
@@ -19,8 +19,8 @@ type Attempt struct {
 	Exhausted     bool               `json:"exhausted" db:"exhausted"`
 
 	ErrorCode *AttemptErrorCode `json:"error_code" db:"error_code"`
-	Request   *AttemptRequest   `json:"request,omitempty" db:"request"`
-	Response  *AttemptResponse  `json:"response,omitempty" db:"response"`
+	Request   *AttemptRequest   `json:"request" db:"request"`
+	Response  *AttemptResponse  `json:"response" db:"response"`
 
 	BaseModel
 }
@@ -69,8 +69,8 @@ const (
 type AttemptRequest struct {
 	Method  string            `json:"method"`
 	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Body    *string           `json:"body,omitempty"`
+	Headers map[string]string `json:"headers"`
+	Body    *string           `json:"body"`
 }
 
 func (m *AttemptRequest) Scan(src interface{}) error {
@@ -84,8 +84,8 @@ func (m AttemptRequest) Value() (driver.Value, error) {
 type AttemptResponse struct {
 	Status  int               `json:"status"`
 	Latency int64             `json:"latency"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Body    *string           `json:"body,omitempty"`
+	Headers map[string]string `json:"headers"`
+	Body    *string           `json:"body"`
 }
 
 func (m *AttemptResponse) Scan(src interface{}) error {

--- a/db/entities/attempt.go
+++ b/db/entities/attempt.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"database/sql/driver"
 	"encoding/json"
+
 	"github.com/webhookx-io/webhookx/pkg/types"
 )
 
@@ -18,10 +19,24 @@ type Attempt struct {
 	Exhausted     bool               `json:"exhausted" db:"exhausted"`
 
 	ErrorCode *AttemptErrorCode `json:"error_code" db:"error_code"`
-	Request   *AttemptRequest   `json:"request" db:"request"`
-	Response  *AttemptResponse  `json:"response" db:"response"`
+	Request   *AttemptRequest   `json:"request,omitempty" db:"request"`
+	Response  *AttemptResponse  `json:"response,omitempty" db:"response"`
 
 	BaseModel
+}
+
+func (m *Attempt) Extend(detail *AttemptDetail) {
+	if detail == nil {
+		return
+	}
+	if m.Request != nil {
+		m.Request.Headers = detail.RequestHeaders
+		m.Request.Body = detail.RequestBody
+	}
+	if m.Response != nil {
+		m.Response.Headers = detail.ResponseHeaders
+		m.Response.Body = detail.ResponseBody
+	}
 }
 
 type AttemptStatus = string
@@ -54,8 +69,8 @@ const (
 type AttemptRequest struct {
 	Method  string            `json:"method"`
 	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
-	Body    *string           `json:"body"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    *string           `json:"body,omitempty"`
 }
 
 func (m *AttemptRequest) Scan(src interface{}) error {
@@ -69,8 +84,8 @@ func (m AttemptRequest) Value() (driver.Value, error) {
 type AttemptResponse struct {
 	Status  int               `json:"status"`
 	Latency int64             `json:"latency"`
-	Headers map[string]string `json:"headers"`
-	Body    *string           `json:"body"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    *string           `json:"body,omitempty"`
 }
 
 func (m *AttemptResponse) Scan(src interface{}) error {

--- a/db/entities/attempt.go
+++ b/db/entities/attempt.go
@@ -39,6 +39,10 @@ func (m *Attempt) Extend(detail *AttemptDetail) {
 	}
 }
 
+func (m *Attempt) Delivered() bool {
+	return m.Status == AttemptStatusSuccess || m.Status == AttemptStatusFailure
+}
+
 type AttemptStatus = string
 
 const (

--- a/db/entities/attempt_detail.go
+++ b/db/entities/attempt_detail.go
@@ -1,0 +1,26 @@
+package entities
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+)
+
+type AttemptDetail struct {
+	ID              string  `json:"id" db:"id"`
+	RequestHeaders  Headers `json:"request_headers" db:"request_headers"`
+	RequestBody     *string `json:"request_body" db:"request_body"`
+	ResponseHeaders Headers `json:"response_headers" db:"response_headers"`
+	ResponseBody    *string `json:"response_body" db:"response_body"`
+
+	BaseModel
+}
+
+type Headers map[string]string
+
+func (m *Headers) Scan(src interface{}) error {
+	return json.Unmarshal(src.([]byte), m)
+}
+
+func (m Headers) Value() (driver.Value, error) {
+	return json.Marshal(m)
+}

--- a/db/migrations/3_create_attempt_details_table.down.sql
+++ b/db/migrations/3_create_attempt_details_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "attempt_details";

--- a/db/migrations/3_create_attempt_details_table.up.sql
+++ b/db/migrations/3_create_attempt_details_table.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "attempt_details" (
+    "id"             CHAR(27) PRIMARY KEY REFERENCES "attempts" ("id") ON DELETE CASCADE,
+
+    "request_headers"     JSONB,
+    "request_body"        JSONB,
+    "response_headers"    JSONB,
+    "response_body"       JSONB,
+
+    "ws_id"          CHAR(27),
+    "created_at"     TIMESTAMPTZ(3)          DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'),
+    "updated_at"     TIMESTAMPTZ(3)          DEFAULT (CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC')
+);
+
+CREATE INDEX idx_attempt_details_ws_id ON attempt_details (ws_id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,16 +36,20 @@ services:
       POSTGRES_USER: webhookx
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
       interval: 3s
       timeout: 5s
       retries: 3
+    ports:
+      - "5432:5432"
     volumes:
       - "postgres_data:/var/lib/postgresql/data/"
 
   redis:
     image: redis:6
     command: "--appendonly yes --appendfsync everysec"
+    ports:
+      - "6379:6379"
     volumes:
       - "redis_data:/data"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,16 +40,12 @@ services:
       interval: 3s
       timeout: 5s
       retries: 3
-    ports:
-      - "5432:5432"
     volumes:
       - "postgres_data:/var/lib/postgresql/data/"
 
   redis:
     image: redis:6
     command: "--appendonly yes --appendfsync everysec"
-    ports:
-      - "6379:6379"
     volumes:
       - "redis_data:/data"
 

--- a/test/delivery/delivery_test.go
+++ b/test/delivery/delivery_test.go
@@ -87,8 +87,7 @@ var _ = Describe("delivery", Ordered, func() {
 				attemptDetail = val
 				return true
 			}, time.Second*5, time.Second)
-			attempt.Extend(attemptDetail)
-			assert.Equal(GinkgoT(), &entities.AttemptRequest{
+			attemptRequest := &entities.AttemptRequest{
 				Method: "POST",
 				URL:    "http://localhost:9999/anything",
 				Headers: map[string]string{
@@ -96,7 +95,12 @@ var _ = Describe("delivery", Ordered, func() {
 					"User-Agent":   "WebhookX/" + config.VERSION,
 				},
 				Body: utils.Pointer(`{"key": "value"}`),
-			}, attempt.Request)
+			}
+			assert.EqualValues(GinkgoT(), attemptRequest.Headers, attemptDetail.RequestHeaders)
+			assert.Equal(GinkgoT(), attemptRequest.Body, attemptDetail.RequestBody)
+
+			attempt.Extend(attemptDetail)
+			assert.Equal(GinkgoT(), attemptRequest, attempt.Request)
 			assert.Equal(GinkgoT(), 200, attempt.Response.Status)
 			assert.NotNil(GinkgoT(), attempt.Response.Headers)
 			assert.NotNil(GinkgoT(), attempt.Response.Body)

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -3,6 +3,9 @@ package helper
 import (
 	"bufio"
 	"context"
+	"os"
+	"time"
+
 	"github.com/creasty/defaults"
 	"github.com/go-resty/resty/v2"
 	"github.com/webhookx-io/webhookx/app"
@@ -11,8 +14,6 @@ import (
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/db/migrator"
 	"github.com/webhookx-io/webhookx/utils"
-	"os"
-	"time"
 )
 
 var cfg *config.Config
@@ -96,10 +97,11 @@ func DB() *db.DB {
 }
 
 type EntitiesConfig struct {
-	Endpoints []*entities.Endpoint
-	Sources   []*entities.Source
-	Events    []*entities.Event
-	Attempts  []*entities.Attempt
+	Endpoints      []*entities.Endpoint
+	Sources        []*entities.Source
+	Events         []*entities.Event
+	Attempts       []*entities.Attempt
+	AttemptDetails []*entities.AttemptDetail
 }
 
 func InitDB(truncated bool, entities *EntitiesConfig) *db.DB {
@@ -151,6 +153,14 @@ func InitDB(truncated bool, entities *EntitiesConfig) *db.DB {
 	for _, e := range entities.Attempts {
 		e.WorkspaceId = ws.ID
 		err = db.Attempts.Insert(context.TODO(), e)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	for _, e := range entities.AttemptDetails {
+		e.WorkspaceId = ws.ID
+		err = db.AttemptDetails.Insert(context.TODO(), e)
 		if err != nil {
 			panic(err)
 		}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -271,10 +271,8 @@ func (w *Worker) handleTask(ctx context.Context, task *queue.TaskMessage) error 
 func buildAttemptResult(request *deliverer.Request, response *deliverer.Response) *dao.AttemptResult {
 	result := &dao.AttemptResult{
 		Request: &entities.AttemptRequest{
-			URL:     request.URL,
-			Method:  request.Method,
-			Headers: utils.HeaderMap(request.Request.Header),
-			Body:    utils.Pointer(string(request.Payload)),
+			URL:    request.URL,
+			Method: request.Method,
 		},
 		Status: entities.AttemptStatusSuccess,
 	}
@@ -295,8 +293,6 @@ func buildAttemptResult(request *deliverer.Request, response *deliverer.Response
 		result.Response = &entities.AttemptResponse{
 			Status:  response.StatusCode,
 			Latency: response.Latancy.Milliseconds(),
-			Headers: utils.HeaderMap(response.Header),
-			Body:    utils.Pointer(string(response.ResponseBody)),
 		}
 	}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -219,7 +219,6 @@ func (w *Worker) handleTask(ctx context.Context, task *queue.TaskMessage) error 
 	attemptDetail.WorkspaceId = endpoint.WorkspaceId
 	err = w.DB.AttemptDetails.Upsert(ctx, attemptDetail)
 	if err != nil {
-		w.log.Warnf(`[worker] failed to save attempt detail: %v`, err)
 		return err
 	}
 


### PR DESCRIPTION
What did this pull request do?
Add `attempt_detail` to save attempt request and response content, instead of save them in `attempts`. 

the request omits `method` and `url` because it always the same with endpoint configured, not necessary in attempts. 
 
Related issue: https://github.com/webhookx-io/webhookx/issues/14

the attempt detail will be :
```
curl http://localhost:8080/workspaces/default/attempts/2mFenI0oG9mET59CuWxYS9UGDbw
```
Response:
```
{
  "request": {
    "headers": {
      "Api-Key": "secret",
      "Content-Type": "application/json; charset=utf-8",
      "User-Agent": "WebhookX/"
    },
    "body": "{\"key\": \"value\"}"
  },
  "response": {
    "status": 200,
    "headers": {
      "Access-Control-Allow-Credentials": "true",
      "Access-Control-Allow-Origin": "*",
      "Content-Length": "503",
      "Content-Type": "application/json",
      "Date": "Wed, 18 Sep 2024 16:28:43 GMT",
      "Server": "gunicorn/19.9.0"
    },
    "body": "{\"url\": \"https://httpbin.org/anything\", \"args\": {}, \"data\": \"{\\\"key\\\": \\\"value\\\"}\", \"form\": {}, \"json\": {\"key\": \"value\"}, \"files\": {}, \"method\": \"POST\", \"origin\": \"1.168.171.163\", \"headers\": {\"Host\": \"httpbin.org\", \"Api-Key\": \"secret\", \"User-Agent\": \"WebhookX/\", \"Content-Type\": \"application/json; charset=utf-8\", \"Content-Length\": \"16\", \"Accept-Encoding\": \"gzip\", \"X-Amzn-Trace-Id\": \"Root=1-66eaffbb-7c582c1117cc4baf2df3f824\"}}"
  },
  "id": "2mFenI0oG9mET59CuWxYS9UGDbw",
  "event_id": "2mFenKA8RDjSokk1owHrM9y4E3b",
  "endpoint_id": "2mFem2OCfnjdBaCvWNmGHeJYD8W",
  "status": "SUCCESSFUL",
  "attempt_number": 1,
  "scheduled_at": 1726676916395,
  "attempted_at": 1726676917262,
  "error_code": null,
  "created_at": 1726676916394,
  "updated_at": 1726676916394
}


```


