### PR TITLE
fix: add missing properties `trigger_mode` and `exhausted`

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -596,6 +596,10 @@ components:
           type: integer
         attempted_at:
           type: integer
+        trigger_mode :
+          type : string
+        exhausted :
+          type: boolean
         request:
           type: object
           properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -596,8 +596,9 @@ components:
           type: integer
         attempted_at:
           type: integer
-        trigger_mode :
+        trigger_mode:
           type : string
+          enum: [INITIAL, MANUAL, AUTOMATIC]
         exhausted :
           type: boolean
         request:

--- a/openapi.yml
+++ b/openapi.yml
@@ -597,7 +597,7 @@ components:
         attempted_at:
           type: integer
         trigger_mode:
-          type : string
+          type: string
           enum: [INITIAL, MANUAL, AUTOMATIC]
         exhausted:
           type: boolean

--- a/openapi.yml
+++ b/openapi.yml
@@ -599,7 +599,7 @@ components:
         trigger_mode:
           type : string
           enum: [INITIAL, MANUAL, AUTOMATIC]
-        exhausted :
+        exhausted:
           type: boolean
         request:
           type: object


### PR DESCRIPTION
### Summary

Add missing properties