### PR TITLE
fix: change request_body and response_body columns to text

### DIFF
--- a/admin/api/attempts.go
+++ b/admin/api/attempts.go
@@ -34,9 +34,22 @@ func (api *API) GetAttempt(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if attempt.AttemptedAt != nil {
-		attemptDetail, err := api.DB.AttemptDetailsWS.Get(r.Context(), attempt.ID)
+		detail, err := api.DB.AttemptDetailsWS.Get(r.Context(), attempt.ID)
 		api.assert(err)
-		attempt.Extend(attemptDetail)
+		if detail != nil {
+			if detail.RequestHeaders != nil {
+				attempt.Request.Headers = detail.RequestHeaders
+			}
+			if detail.RequestBody != nil {
+				attempt.Request.Body = detail.RequestBody
+			}
+			if detail.ResponseHeaders != nil {
+				attempt.Response.Headers = *detail.ResponseHeaders
+			}
+			if detail.ResponseBody != nil {
+				attempt.Response.Body = detail.ResponseBody
+			}
+		}
 	}
 
 	api.json(200, w, attempt)

--- a/db/entities/attempt.go
+++ b/db/entities/attempt.go
@@ -25,20 +25,6 @@ type Attempt struct {
 	BaseModel
 }
 
-func (m *Attempt) Extend(detail *AttemptDetail) {
-	if detail == nil {
-		return
-	}
-	if m.Request != nil {
-		m.Request.Headers = detail.RequestHeaders
-		m.Request.Body = detail.RequestBody
-	}
-	if m.Response != nil {
-		m.Response.Headers = detail.ResponseHeaders
-		m.Response.Body = detail.ResponseBody
-	}
-}
-
 type AttemptStatus = string
 
 const (
@@ -67,10 +53,10 @@ const (
 )
 
 type AttemptRequest struct {
-	Method  string            `json:"method"`
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
-	Body    *string           `json:"body"`
+	Method  string  `json:"method"`
+	URL     string  `json:"url"`
+	Headers Headers `json:"headers"`
+	Body    *string `json:"body"`
 }
 
 func (m *AttemptRequest) Scan(src interface{}) error {
@@ -82,10 +68,10 @@ func (m AttemptRequest) Value() (driver.Value, error) {
 }
 
 type AttemptResponse struct {
-	Status  int               `json:"status"`
-	Latency int64             `json:"latency"`
-	Headers map[string]string `json:"headers"`
-	Body    *string           `json:"body"`
+	Status  int     `json:"status"`
+	Latency int64   `json:"latency"`
+	Headers Headers `json:"headers"`
+	Body    *string `json:"body"`
 }
 
 func (m *AttemptResponse) Scan(src interface{}) error {

--- a/db/entities/attempt_detail.go
+++ b/db/entities/attempt_detail.go
@@ -1,26 +1,11 @@
 package entities
 
-import (
-	"database/sql/driver"
-	"encoding/json"
-)
-
 type AttemptDetail struct {
-	ID              string  `json:"id" db:"id"`
-	RequestHeaders  Headers `json:"request_headers" db:"request_headers"`
-	RequestBody     *string `json:"request_body" db:"request_body"`
-	ResponseHeaders Headers `json:"response_headers" db:"response_headers"`
-	ResponseBody    *string `json:"response_body" db:"response_body"`
+	ID              string   `json:"id" db:"id"`
+	RequestHeaders  Headers  `json:"request_headers" db:"request_headers"`
+	RequestBody     *string  `json:"request_body" db:"request_body"`
+	ResponseHeaders *Headers `json:"response_headers" db:"response_headers"`
+	ResponseBody    *string  `json:"response_body" db:"response_body"`
 
 	BaseModel
-}
-
-type Headers map[string]string
-
-func (m *Headers) Scan(src interface{}) error {
-	return json.Unmarshal(src.([]byte), m)
-}
-
-func (m Headers) Value() (driver.Value, error) {
-	return json.Marshal(m)
 }

--- a/db/entities/types.go
+++ b/db/entities/types.go
@@ -21,3 +21,13 @@ type BaseModel struct {
 	UpdatedAt   types.Time `db:"updated_at" json:"updated_at"`
 	WorkspaceId string     `db:"ws_id" json:"-"`
 }
+
+type Headers map[string]string
+
+func (m *Headers) Scan(src interface{}) error {
+	return json.Unmarshal(src.([]byte), m)
+}
+
+func (m Headers) Value() (driver.Value, error) {
+	return json.Marshal(m)
+}

--- a/db/migrations/5_fix_attempt_details.down.sql
+++ b/db/migrations/5_fix_attempt_details.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS ONLY "attempt_details" ALTER COLUMN request_body TYPE JSONB USING request_body::JSONB;
+ALTER TABLE IF EXISTS ONLY "attempt_details" ALTER COLUMN response_body TYPE JSONB USING response_body::JSONB;

--- a/db/migrations/5_fix_attempt_details.up.sql
+++ b/db/migrations/5_fix_attempt_details.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS ONLY "attempt_details" ALTER COLUMN request_body TYPE TEXT;
+ALTER TABLE IF EXISTS ONLY "attempt_details" ALTER COLUMN response_body TYPE TEXT;

--- a/test/admin/attempts_test.go
+++ b/test/admin/attempts_test.go
@@ -211,7 +211,7 @@ var _ = Describe("/attempts", Ordered, func() {
 						"Content-Type": "application/json",
 					},
 					RequestBody: utils.Pointer(`{"key": "value"}`),
-					ResponseHeaders: map[string]string{
+					ResponseHeaders: &entities.Headers{
 						"Content-Type": "application/json",
 					},
 				}
@@ -237,7 +237,7 @@ var _ = Describe("/attempts", Ordered, func() {
 
 				assert.EqualValues(GinkgoT(), detail.RequestHeaders, result.Request.Headers)
 				assert.EqualValues(GinkgoT(), detail.RequestBody, result.Request.Body)
-				assert.EqualValues(GinkgoT(), detail.ResponseHeaders, result.Response.Headers)
+				assert.EqualValues(GinkgoT(), detail.ResponseHeaders, &result.Response.Headers)
 				assert.EqualValues(GinkgoT(), detail.ResponseBody, result.Response.Body)
 				assert.EqualValues(GinkgoT(), 200, result.Response.Status)
 			})

--- a/test/admin/attempts_test.go
+++ b/test/admin/attempts_test.go
@@ -214,6 +214,7 @@ var _ = Describe("/attempts", Ordered, func() {
 					ResponseHeaders: &entities.Headers{
 						"Content-Type": "application/json",
 					},
+					ResponseBody: utils.Pointer("the response body"),
 				}
 				entitiesConfig.AttemptDetails = []*entities.AttemptDetail{detail}
 

--- a/test/delivery/delivery_test.go
+++ b/test/delivery/delivery_test.go
@@ -107,11 +107,6 @@ var _ = Describe("delivery", Ordered, func() {
 			timestamp := attemptDetail.RequestHeaders["Webhookx-Timestamp"]
 			assert.True(GinkgoT(), utils.Must(strconv.ParseInt(timestamp, 10, 0)) >= attempt.AttemptedAt.Unix())
 			assert.Equal(GinkgoT(), `{"key": "value"}`, *attemptDetail.RequestBody)
-
-			// attemptDetail.response
-			attempt.Extend(attemptDetail)
-			assert.NotNil(GinkgoT(), attempt.Response.Headers)
-			assert.NotNil(GinkgoT(), attempt.Response.Body)
 		})
 	})
 
@@ -176,8 +171,8 @@ var _ = Describe("delivery", Ordered, func() {
 
 				attemptDetail, err := db.AttemptDetails.Get(context.TODO(), e.ID)
 				assert.NoError(GinkgoT(), err)
-				e.Extend(attemptDetail)
-				assert.Nil(GinkgoT(), e.Response)
+				assert.Nil(GinkgoT(), attemptDetail.ResponseHeaders)
+				assert.Nil(GinkgoT(), attemptDetail.ResponseBody)
 			}
 		})
 	})

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -243,7 +243,7 @@ func (w *Worker) handleTask(ctx context.Context, task *queue.TaskMessage) error 
 		RequestBody:    utils.Pointer(string(request.Payload)),
 	}
 	if len(response.Header) > 0 {
-		attemptDetail.ResponseHeaders = utils.HeaderMap(response.Header)
+		attemptDetail.ResponseHeaders = utils.Pointer(entities.Headers(utils.HeaderMap(response.Header)))
 	}
 	if response.ResponseBody != nil {
 		attemptDetail.ResponseBody = utils.Pointer(string(response.ResponseBody))


### PR DESCRIPTION
### Summary

1. Fixed AtteptDetail insertion may fail when the response body is not JSON
2. Changed AttemptDetailt.ResponseBody to pointer type to not store literal `null` in the database.