### PR TITLE
feat: use pool to limit goroutine

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -87,7 +87,10 @@ func (app *Application) initialize() error {
 
 	// worker
 	if cfg.WorkerConfig.Enabled {
-		opts := worker.WorkerOptions{}
+		opts := worker.WorkerOptions{
+			PoolSize:        int(cfg.WorkerConfig.Pool.Size),
+			PoolConcurrency: int(cfg.WorkerConfig.Pool.Concurrency),
+		}
 		deliverer := deliverer.NewHTTPDeliverer(&cfg.WorkerConfig.Deliverer)
 		app.worker = worker.NewWorker(opts, db, deliverer, queue)
 	}

--- a/config.yml
+++ b/config.yml
@@ -37,6 +37,9 @@ worker:
   enabled: false
   deliverer:
     timeout: 60000
+  pool:
+    size: 10000                     # pool size, default to 10000.
+    concurrency: 0                  # pool concurrency, default to 100 * CPUs
 
 #------------------------------------------------------------------------------
 # PROXY

--- a/config/worker.go
+++ b/config/worker.go
@@ -4,9 +4,15 @@ type WorkerDeliverer struct {
 	Timeout int64 `yaml:"timeout" default:"60000"`
 }
 
+type Pool struct {
+	Size        uint32 `yaml:"size" default:"10000"`
+	Concurrency uint32 `yaml:"concurrency"`
+}
+
 type WorkerConfig struct {
 	Enabled   bool            `yaml:"enabled" default:"false"`
 	Deliverer WorkerDeliverer `yaml:"deliverer"`
+	Pool      Pool            `yaml:"pool"`
 }
 
 func (cfg *WorkerConfig) Validate() error {

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -1,0 +1,90 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrPoolTernimated = errors.New("pool is ternimated")
+	ErrTimeout        = errors.New("timeout")
+)
+
+type Pool struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	workers int
+
+	tasks chan Task
+	wait  sync.WaitGroup
+}
+
+func NewPool(size int, workers int) *Pool {
+	ctx, cancel := context.WithCancel(context.Background())
+	pool := &Pool{
+		ctx:     ctx,
+		cancel:  cancel,
+		workers: workers,
+		tasks:   make(chan Task, size),
+	}
+
+	pool.wait.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go pool.consume()
+	}
+
+	return pool
+}
+
+func (p *Pool) SubmitFn(timeout time.Duration, fn func()) error {
+	if fn == nil {
+		return errors.New("fn is nil")
+	}
+
+	taks := &task{
+		fn: fn,
+	}
+	return p.Submit(timeout, taks)
+}
+
+func (p *Pool) Submit(timeout time.Duration, task Task) error {
+	if task == nil {
+		return errors.New("task is nil")
+	}
+
+	if p.ctx.Err() != nil {
+		return ErrPoolTernimated
+	}
+
+	select {
+	case p.tasks <- task:
+		return nil
+	case <-time.After(timeout):
+		return ErrTimeout
+	}
+}
+
+func (p *Pool) consume() {
+	defer p.wait.Done()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case t := <-p.tasks:
+			t.Execute()
+		}
+	}
+}
+
+func (p *Pool) Shutdown() {
+	if err := p.ctx.Err(); err != nil {
+		return
+	}
+
+	p.cancel()
+	p.wait.Wait()
+}

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -1,0 +1,80 @@
+package pool
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestError(t *testing.T) {
+	pool := NewPool(0, 1)
+
+	err := pool.SubmitFn(time.Second, nil)
+	assert.Equal(t, "fn is nil", err.Error())
+
+	err = pool.Submit(time.Second, nil)
+	assert.Equal(t, "task is nil", err.Error())
+
+	// panic should be recovered
+	err = pool.SubmitFn(time.Second, func() {
+		panic("foo")
+	})
+	assert.NoError(t, err)
+
+	pool.Shutdown()
+	pool.Shutdown() // no panic
+}
+
+func TestSubmit(t *testing.T) {
+	pool := NewPool(5, 1)
+	wait := sync.WaitGroup{}
+	for i := 0; i < 5; i++ {
+		wait.Add(1)
+		err := pool.SubmitFn(time.Second, func() {
+			wait.Done()
+		})
+		assert.NoError(t, err)
+	}
+	wait.Wait()
+}
+
+func TestSubmitWithTimeout(t *testing.T) {
+	pool := NewPool(1, 1)
+	err := pool.SubmitFn(time.Second, func() {
+		time.Sleep(time.Second * 5)
+	})
+	assert.NoError(t, err)
+	err = pool.SubmitFn(time.Second, func() {
+		time.Sleep(time.Second * 5)
+	})
+	assert.NoError(t, err)
+	err = pool.SubmitFn(time.Second, func() {})
+	assert.Equal(t, ErrTimeout, err)
+}
+
+func TestShutdown(t *testing.T) {
+	pool := NewPool(1, 1)
+	pool.Shutdown()
+	err := pool.SubmitFn(time.Second, func() {})
+	assert.Equal(t, ErrPoolTernimated, err)
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	var counter int64
+	atomic.StoreInt64(&counter, 0)
+
+	pool := NewPool(100, 100)
+
+	for i := 0; i < 100; i++ {
+		err := pool.SubmitFn(time.Second, func() {
+			time.Sleep(time.Second)
+			atomic.AddInt64(&counter, 1)
+		})
+		assert.NoError(t, err)
+	}
+
+	pool.Shutdown()
+	assert.EqualValues(t, 100, counter) // all submitted and scheduled tasks should be executed successfully
+}

--- a/pkg/pool/task.go
+++ b/pkg/pool/task.go
@@ -1,0 +1,26 @@
+package pool
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type Task interface {
+	Execute()
+}
+
+type task struct {
+	fn func()
+}
+
+func (t *task) Execute() {
+	defer func() {
+		if e := recover(); e != nil {
+			buf := make([]byte, 2048)
+			n := runtime.Stack(buf, false)
+			buf = buf[:n]
+			fmt.Printf("panic recovered: %v\n %s\n", e, buf)
+		}
+	}()
+	t.fn()
+}


### PR DESCRIPTION
### Summary

Introduce `worker.pool` configuration to limit the goroutine pool size and concurrency. 
