### PR TITLE
chore: upgrade go version to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS build-env
+FROM golang:1.23 AS build-env
 
 WORKDIR /go/src/webhookx-io/webhookx
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/webhookx-io/webhookx
 
-go 1.22.0
+go 1.23
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` and `go.mod` files to upgrade the Go version used in the project.

Version upgrades:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Updated the base image from `golang:1.22` to `golang:1.23`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.22.0` to `1.23`.