### PR TITLE
fix(test): pool test graceful shutdown failed

### DIFF
--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -61,20 +61,21 @@ func TestShutdown(t *testing.T) {
 	assert.Equal(t, ErrPoolTernimated, err)
 }
 
-func TestGracefulShutdown(t *testing.T) {
-	var counter int64
-	atomic.StoreInt64(&counter, 0)
+func BenchmarkGracefulShutdown(t *testing.B) {
+	var counter atomic.Int64
 
 	pool := NewPool(100, 100)
 
 	for i := 0; i < 100; i++ {
 		err := pool.SubmitFn(time.Second, func() {
 			time.Sleep(time.Second)
-			atomic.AddInt64(&counter, 1)
+			counter.Add(1)
 		})
 		assert.NoError(t, err)
 	}
+	// wait for all tasks to be scheduled
+	time.Sleep(time.Second)
 
 	pool.Shutdown()
-	assert.EqualValues(t, 100, counter) // all submitted and scheduled tasks should be executed successfully
+	assert.EqualValues(t, 100, counter.Load()) // all submitted and scheduled tasks should be executed successfully
 }


### PR DESCRIPTION
Description:

the unit test is flaky failed with the pool_test `TestGracefulShutdown` method, i found a stable reproduction path:
with limit cpu performance, the submit task channel is not fully consumed before the pool shutdown.

```
func BenchmarkGracefulShutdown(t *testing.B) {
	var counter int64
	atomic.StoreInt64(&counter, 0)

	pool := NewPool(100, 100)

	for i := 0; i < 100; i++ {
		err := pool.SubmitFn(time.Second, func() {
			time.Sleep(time.Second)
			atomic.AddInt64(&counter, 1)
		})
		assert.NoError(t, err)
	}

	pool.Shutdown()
	assert.EqualValues(t, 100, counter) // all submitted and scheduled tasks should be executed successfully
}
```

the test cmd and result:
```
go test -benchmem -run=^$ -bench ^BenchmarkGracefulShutdown$ -cpu=1 -count=10 github.com/webhookx-io/webhookx/pkg/pool
goos: darwin
goarch: amd64
pkg: github.com/webhookx-io/webhookx/pkg/pool
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkGracefulShutdown 	       1	4003391923 ns/op	   85176 B/op	     776 allocs/op
BenchmarkGracefulShutdown 	--- FAIL: BenchmarkGracefulShutdown
    pool_test.go:79:
        	Error Trace:	/Users/ccheng/vscode/webhookx/pkg/pool/pool_test.go:79
        	Error:      	Not equal:
        	            	expected: int(100)
        	            	actual  : int64(80)
        	Test:       	BenchmarkGracefulShutdown
```
