### PR TITLE
feat(declarative): declarative configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ WebhookX is an open-source webhooks gateway for message receiving, processing, a
 - **Admin API:** The admin API(:8080) provides a RESTful API for webhooks entities management.
 - **Retries:** WebhookX automatically retries unsuccessful deliveries at configurable delays.
 - **Fan out:** Events can be fan out to multiple destinations.
-- **Declarative configuration(WIP):**  Managing your configuration through declarative configuration file, and be DevOps compliant.
+- **Declarative configuration:** Managing your configuration through declarative configuration file, and be GitOps and DevOps compliant.
 - **Multi-tenancy:** Multi-tenancy is supported with workspaces. Workspaces provide an isolation of configuration entites.
 - **Plugins:**
   - `webhookx-signature`: signing outbound requests with HMAC(SHA-256) by adding `Webhookx-Signature` and `Webhookx-Timestamp` to request header.
@@ -22,7 +22,6 @@ WebhookX is an open-source webhooks gateway for message receiving, processing, a
 
 - [ ] Data retention policy
 - [ ] Insight admin APIs
-- [ ] Declarative configuration management
 
 #### Inbound
 
@@ -32,51 +31,45 @@ WebhookX is an open-source webhooks gateway for message receiving, processing, a
 
 ## Installation
 
+
+### macOS
+
 ```shell
+$ brew tap webhookx-io/webhookx
+$ brew install webhookx
+```
+
+### Linux
+
+- Download the binary distribution on [releases](https://github.com/webhookx-io/webhookx/releases).
+
+### Windows:
+
+- Download the binary distribution on [releases](https://github.com/webhookx-io/webhookx/releases).
+
+## Getting started
+
+
+#### 1. Running WebhookX
+
+```
+$ curl -O https://raw.githubusercontent.com/webhookx-io/webhookx/main/docker-compose.yml
 $ docker compose up
 ```
 
-```shell
+verify running
+
+```
 $ curl http://localhost:8080
 ```
 
 
-## Getting started
-
-#### 1. Create an endpoint that subscribes to specific events
-
-> **Endpoint** represents the event's destination.
+#### 2. Setup configuration
 
 ```
-$ curl -X POST http://localhost:8080/workspaces/default/endpoints \
-  --header 'Content-Type: application/json' \
-  --data '{
-      "request": {
-          "url": "https://httpbin.org/anything",
-          "method": "POST",
-          "headers": {
-              "api-key": "secret"
-          }
-      },
-      "events": [
-          "charge.succeeded"
-      ]
-  }'
+$ webhookx admin sync webhookx.sample.yml
 ```
 
-#### 2. Create a source that is used on the Proxy for receiving events
-
-> **Source** represents the ingress of events
-
-```
-$ curl -X POST http://localhost:8080/workspaces/default/sources \
-  --header 'accept: application/json' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "path": "/",
-    "methods": ["POST"]
-  }'
-```
 
 #### 3. Send an event to the Proxy (port 8081)
 

--- a/admin/api/api.go
+++ b/admin/api/api.go
@@ -7,6 +7,7 @@ import (
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/query"
 	"github.com/webhookx-io/webhookx/dispatcher"
+	"github.com/webhookx-io/webhookx/pkg/declarative"
 	"github.com/webhookx-io/webhookx/pkg/errs"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -20,20 +21,22 @@ const (
 )
 
 type API struct {
-	cfg        *config.Config
-	log        *zap.SugaredLogger
-	DB         *db.DB
-	dispatcher *dispatcher.Dispatcher
-	tracer     *tracing.Tracer
+	cfg         *config.Config
+	log         *zap.SugaredLogger
+	DB          *db.DB
+	dispatcher  *dispatcher.Dispatcher
+	tracer      *tracing.Tracer
+	declarative *declarative.Declarative
 }
 
 func NewAPI(cfg *config.Config, db *db.DB, dispatcher *dispatcher.Dispatcher, tracer *tracing.Tracer) *API {
 	return &API{
-		cfg:        cfg,
-		log:        zap.S(),
-		DB:         db,
-		dispatcher: dispatcher,
-		tracer:     tracer,
+		cfg:         cfg,
+		log:         zap.S(),
+		DB:          db,
+		dispatcher:  dispatcher,
+		tracer:      tracer,
+		declarative: declarative.NewDeclarative(db),
 	}
 }
 
@@ -51,13 +54,21 @@ func (api *API) json(code int, w http.ResponseWriter, data interface{}) {
 	w.Header().Set("Content-Type", ApplicationJsonType)
 	w.WriteHeader(code)
 
-	if data != nil {
-		bytes, err := json.Marshal(data)
-		if err != nil {
-			panic(err)
-		}
-		_, _ = w.Write(bytes)
+	if data == nil {
+		return
 	}
+
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	_, _ = w.Write(bytes)
+}
+
+func (api *API) text(code int, w http.ResponseWriter, bytes []byte) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(code)
+	_, _ = w.Write(bytes)
 }
 
 func (api *API) bindQuery(r *http.Request, q *query.Query) {
@@ -105,6 +116,9 @@ func (api *API) Handler() http.Handler {
 	r.Use(api.contextMiddleware)
 
 	r.HandleFunc("/", api.Index).Methods("GET")
+
+	r.HandleFunc("/workspaces/{workspace}/sync", api.Sync).Methods("POST")
+	r.HandleFunc("/workspaces/{workspace}/dump", api.Dump).Methods("POST")
 
 	r.HandleFunc("/workspaces", api.PageWorkspace).Methods("GET")
 	r.HandleFunc("/workspaces", api.CreateWorkspace).Methods("POST")

--- a/admin/api/api.go
+++ b/admin/api/api.go
@@ -117,8 +117,8 @@ func (api *API) Handler() http.Handler {
 
 	r.HandleFunc("/", api.Index).Methods("GET")
 
-	r.HandleFunc("/workspaces/{workspace}/sync", api.Sync).Methods("POST")
-	r.HandleFunc("/workspaces/{workspace}/dump", api.Dump).Methods("POST")
+	r.HandleFunc("/workspaces/{workspace}/config/sync", api.Sync).Methods("POST")
+	r.HandleFunc("/workspaces/{workspace}/config/dump", api.Dump).Methods("POST")
 
 	r.HandleFunc("/workspaces", api.PageWorkspace).Methods("GET")
 	r.HandleFunc("/workspaces", api.CreateWorkspace).Methods("POST")

--- a/admin/api/api.go
+++ b/admin/api/api.go
@@ -65,10 +65,10 @@ func (api *API) json(code int, w http.ResponseWriter, data interface{}) {
 	_, _ = w.Write(bytes)
 }
 
-func (api *API) text(code int, w http.ResponseWriter, bytes []byte) {
+func (api *API) text(code int, w http.ResponseWriter, body string) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(code)
-	_, _ = w.Write(bytes)
+	_, _ = w.Write([]byte(body))
 }
 
 func (api *API) bindQuery(r *http.Request, q *query.Query) {

--- a/admin/api/declarative.go
+++ b/admin/api/declarative.go
@@ -73,5 +73,5 @@ func (api *API) Dump(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	api.text(200, w, buf.Bytes())
+	api.text(200, w, buf.String())
 }

--- a/admin/api/declarative.go
+++ b/admin/api/declarative.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/webhookx-io/webhookx/pkg/declarative"
+	"github.com/webhookx-io/webhookx/pkg/ucontext"
+	"gopkg.in/yaml.v3"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func toJSON(yamlstr []byte) ([]byte, error) {
+	data := make(map[string]interface{})
+	err := yaml.Unmarshal(yamlstr, &data)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(data)
+}
+
+func (api *API) Sync(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	api.assert(err)
+	defer r.Body.Close()
+
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		body, err = toJSON(body)
+		if err != nil {
+			api.error(400, w, errors.New("malformed yaml content: "+err.Error()))
+			return
+		}
+	}
+
+	var cfg declarative.Configuration
+	err = json.Unmarshal(body, &cfg)
+	if err != nil {
+		api.error(400, w, errors.New("invalid yaml content: "+err.Error()))
+		return
+	}
+
+	if err := cfg.Validate(); err != nil {
+		api.error(400, w, errors.New("invalid configuration: "+err.Error()))
+		return
+	}
+
+	wid := ucontext.GetWorkspaceID(r.Context())
+	err = api.declarative.Sync(wid, cfg)
+	api.assert(err)
+
+	api.json(200, w, nil)
+}
+
+func (api *API) Dump(w http.ResponseWriter, r *http.Request) {
+	wid := ucontext.GetWorkspaceID(r.Context())
+	cfg, err := api.declarative.Dump(r.Context(), wid)
+	if err != nil {
+		api.error(400, w, err)
+		return
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	defer encoder.Close()
+
+	err = encoder.Encode(cfg)
+	if err != nil {
+		api.error(400, w, err)
+		return
+	}
+
+	api.text(200, w, buf.Bytes())
+}

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newAdminCmd() *cobra.Command {
+	admin := &cobra.Command{
+		Use:   "admin",
+		Short: "Admin commands",
+		Long:  ``,
+	}
+
+	admin.AddCommand(newAdminSyncCmd())
+	admin.AddCommand(newAdminDumpCmd())
+
+	return admin
+}

--- a/cmd/admin_dump.go
+++ b/cmd/admin_dump.go
@@ -19,7 +19,7 @@ func newAdminDumpCmd() *cobra.Command {
 		Short: "Dump entities to declarative configuration",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			url := fmt.Sprintf("%s/workspaces/%s/dump", addr, workspace)
+			url := fmt.Sprintf("%s/workspaces/%s/config/dump", addr, workspace)
 			r, err := http.NewRequest("POST", url, nil)
 			if err != nil {
 				return err

--- a/cmd/admin_dump.go
+++ b/cmd/admin_dump.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"net/http"
+	"time"
+)
+
+func newAdminDumpCmd() *cobra.Command {
+	var (
+		addr      string
+		timeout   int
+		workspace string
+	)
+
+	dump := &cobra.Command{
+		Use:   "dump",
+		Short: "Dump WebhookX entities to a declarative configuration",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			url := fmt.Sprintf("%s/workspaces/%s/dump", addr, workspace)
+			r, err := http.NewRequest("POST", url, nil)
+			if err != nil {
+				return err
+			}
+
+			content, err := sendHTTPRequest(r, time.Duration(timeout)*time.Second)
+			if err != nil {
+				return err
+			}
+
+			cmd.Print(content)
+			return nil
+		},
+	}
+
+	dump.Flags().StringVarP(&workspace, "workspace", "", "default", "Set a specific workspace.")
+	dump.Flags().StringVarP(&addr, "addr", "", defaultAdminURL, "HTTP address of WebhookX's Admin API.")
+	dump.Flags().IntVarP(&timeout, "timeout", "", 10, "Set the request timeout for the client to connect with WebhookX (in seconds).")
+
+	return dump
+}

--- a/cmd/admin_dump.go
+++ b/cmd/admin_dump.go
@@ -16,7 +16,7 @@ func newAdminDumpCmd() *cobra.Command {
 
 	dump := &cobra.Command{
 		Use:   "dump",
-		Short: "Dump WebhookX entities to a declarative configuration",
+		Short: "Dump entities to declarative configuration",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := fmt.Sprintf("%s/workspaces/%s/dump", addr, workspace)

--- a/cmd/admin_sync.go
+++ b/cmd/admin_sync.go
@@ -28,7 +28,7 @@ func newAdminSyncCmd() *cobra.Command {
 				return err
 			}
 
-			url := fmt.Sprintf("%s/workspaces/%s/sync", addr, workspace)
+			url := fmt.Sprintf("%s/workspaces/%s/config/sync", addr, workspace)
 			r, err := http.NewRequest("POST", url, bytes.NewBuffer(b))
 			if err != nil {
 				return err

--- a/cmd/admin_sync.go
+++ b/cmd/admin_sync.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/spf13/cobra"
+	"net/http"
+	"os"
+	"time"
+)
+
+func newAdminSyncCmd() *cobra.Command {
+	var (
+		addr      string
+		timeout   int
+		workspace string
+	)
+
+	sync := &cobra.Command{
+		Use:   "sync [flags] filename",
+		Short: "Synchronize a declarative configuration to WebhookX.",
+		Long:  ``,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filename := args[0]
+			b, err := os.ReadFile(filename)
+			if err != nil {
+				return err
+			}
+
+			url := fmt.Sprintf("%s/workspaces/%s/sync", addr, workspace)
+			r, err := http.NewRequest("POST", url, bytes.NewBuffer(b))
+			if err != nil {
+				return err
+			}
+
+			r.Header.Add("Content-Type", "text/plain")
+			_, err = sendHTTPRequest(r, time.Duration(timeout)*time.Second)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	sync.Flags().StringVarP(&workspace, "workspace", "", "default", "Set a specific workspace.")
+	sync.Flags().StringVarP(&addr, "addr", "", defaultAdminURL, "HTTP address of WebhookX's Admin API.")
+	sync.Flags().IntVarP(&timeout, "timeout", "", 10, "Set the request timeout for the client to connect with WebhookX (in seconds).")
+
+	return sync
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,25 +6,15 @@ import (
 	"os"
 )
 
-var (
-	configurationFile string
-	cfg               *config.Config
-
-	cmd = &cobra.Command{
-		Use:          "webhookx",
-		Short:        "",
-		Long:         ``,
-		SilenceUsage: true,
-	}
+const (
+	defaultAdminURL = "http://localhost:8080"
 )
 
-func init() {
-	cobra.OnInitialize(initConfig)
-
-	cmd.AddCommand(newVersionCmd())
-	cmd.AddCommand(newMigrationsCmd())
-	cmd.AddCommand(newStartCmd())
-}
+var (
+	configurationFile string
+	verbose           bool
+	cfg               *config.Config
+)
 
 func initConfig() {
 	var err error
@@ -39,8 +29,28 @@ func initConfig() {
 	cobra.CheckErr(err)
 }
 
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "webhookx",
+		Short:        "",
+		Long:         ``,
+		SilenceUsage: true,
+	}
+	cobra.OnInitialize(initConfig)
+
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "Verbose logging.")
+
+	cmd.AddCommand(newVersionCmd())
+	cmd.AddCommand(newMigrationsCmd())
+	cmd.AddCommand(newStartCmd())
+	cmd.AddCommand(newAdminCmd())
+
+	return cmd
+}
+
 func Execute() {
-	if err := cmd.Execute(); err != nil {
+	rootCmd := NewRootCmd()
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func NewRootCmd() *cobra.Command {
 	}
 	cobra.OnInitialize(initConfig)
 
+	cmd.SetOut(os.Stdout)
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "Verbose logging.")
 
 	cmd.AddCommand(newVersionCmd())

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
-	"time"
 )
 
 var ANSWERS = map[string]bool{
@@ -20,26 +17,4 @@ func prompt(q string) bool {
 	var answer string
 	_, _ = fmt.Scan(&answer)
 	return ANSWERS[strings.ToLower(answer)]
-}
-
-func sendHTTPRequest(req *http.Request, timeout time.Duration) (string, error) {
-	client := http.Client{
-		Timeout: timeout,
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("invalid status code: %d %s", resp.StatusCode, string(b))
-	}
-
-	return string(b), nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
+	"time"
 )
 
 var ANSWERS = map[string]bool{
@@ -17,4 +20,26 @@ func prompt(q string) bool {
 	var answer string
 	_, _ = fmt.Scan(&answer)
 	return ANSWERS[strings.ToLower(answer)]
+}
+
+func sendHTTPRequest(req *http.Request, timeout time.Duration) (string, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid status code: %d %s", resp.StatusCode, string(b))
+	}
+
+	return string(b), nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/webhookx-io/webhookx/config"
 )
@@ -12,7 +11,7 @@ func newVersionCmd() *cobra.Command {
 		Short: "Print the version",
 		Long:  `Print the version with a short commit hash.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("WebhookX %s (%s) \n", config.VERSION, config.COMMIT)
+			cmd.Printf("WebhookX %s (%s)\n", config.VERSION, config.COMMIT)
 		},
 	}
 }

--- a/db/dao/attempt_detail_dao.go
+++ b/db/dao/attempt_detail_dao.go
@@ -3,12 +3,13 @@ package dao
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/webhookx-io/webhookx/constants"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"go.opentelemetry.io/otel/trace"
-	"time"
 )
 
 type attemptDetailDao struct {
@@ -28,7 +29,7 @@ func NewAttemptDetailDao(db *sqlx.DB, workspace bool) AttemptDetailDAO {
 	}
 }
 
-func (dao *attemptDetailDao) Upsert(ctx context.Context, attemptDetail *entities.AttemptDetail) error {
+func (dao *attemptDetailDao) Insert(ctx context.Context, attemptDetail *entities.AttemptDetail) error {
 	tracingCtx, span := tracing.Start(ctx, fmt.Sprintf("dao.%s.upsert", dao.opts.Table), trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 	ctx = tracingCtx

--- a/db/dao/daos.go
+++ b/db/dao/daos.go
@@ -9,8 +9,10 @@ import (
 
 type BaseDAO[T any] interface {
 	Get(ctx context.Context, id string) (*T, error)
+	Select(ctx context.Context, field string, id string) (*T, error)
 	Insert(ctx context.Context, entity *T) error
 	Update(ctx context.Context, entity *T) error
+	Upsert(ctx context.Context, fields []string, entity *T) error
 	Delete(ctx context.Context, id string) (bool, error)
 	Page(ctx context.Context, q query.Queryer) ([]*T, int64, error)
 	List(ctx context.Context, q query.Queryer) ([]*T, error)
@@ -47,7 +49,7 @@ type SourceDAO interface {
 
 type AttemptDetailDAO interface {
 	BaseDAO[entities.AttemptDetail]
-	Upsert(ctx context.Context, attemptDetail *entities.AttemptDetail) error
+	Insert(ctx context.Context, attemptDetail *entities.AttemptDetail) error
 }
 
 type PluginDAO interface {

--- a/db/entities/endpoint.go
+++ b/db/entities/endpoint.go
@@ -16,7 +16,7 @@ type Endpoint struct {
 	Retry       Retry          `json:"retry" db:"retry"`
 	Events      pq.StringArray `json:"events" db:"events"`
 
-	BaseModel
+	BaseModel `yaml:"-"`
 }
 
 func (m *Endpoint) Init() {

--- a/db/entities/plugin.go
+++ b/db/entities/plugin.go
@@ -2,24 +2,64 @@ package entities
 
 import (
 	"encoding/json"
+	"errors"
+	"github.com/creasty/defaults"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
 type Plugin struct {
-	ID         string          `json:"id" validate:"required"`
-	Name       string          `json:"name" validate:"required"`
-	Enabled    bool            `json:"enabled" db:"enabled" default:"true"`
-	EndpointId string          `json:"endpoint_id" db:"endpoint_id" validate:"required"`
-	Config     json.RawMessage `json:"config"`
+	ID         string              `json:"id" validate:"required"`
+	Name       string              `json:"name" validate:"required"`
+	Enabled    bool                `json:"enabled" db:"enabled" default:"true"`
+	EndpointId string              `json:"endpoint_id" db:"endpoint_id" validate:"required" yaml:"endpoint_id"`
+	Config     PluginConfiguration `json:"config"`
 
-	BaseModel
+	BaseModel `yaml:"-"`
 }
 
 func (m *Plugin) Validate() error {
 	return utils.Validate(m)
 }
 
+func (m *Plugin) UnmarshalJSON(data []byte) error {
+	err := defaults.Set(m)
+	if err != nil {
+		return err
+	}
+	type alias Plugin
+	return json.Unmarshal(data, (*alias)(m))
+}
+
 func (m *Plugin) Init() {
 	m.ID = utils.KSUID()
 	m.Enabled = true
+}
+
+type PluginConfiguration json.RawMessage
+
+func (m PluginConfiguration) MarshalYAML() (interface{}, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	data := make(map[string]interface{})
+	err := json.Unmarshal(m, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (m PluginConfiguration) MarshalJSON() ([]byte, error) {
+	if m == nil {
+		return []byte("null"), nil
+	}
+	return m, nil
+}
+
+func (m *PluginConfiguration) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("json.RawMessage: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
 }

--- a/db/entities/source.go
+++ b/db/entities/source.go
@@ -3,13 +3,14 @@ package entities
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"github.com/creasty/defaults"
 	"github.com/lib/pq"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
 type CustomResponse struct {
 	Code        int    `json:"code" validate:"required,gte=200,lte=599"`
-	ContentType string `json:"content_type" validate:"required"`
+	ContentType string `json:"content_type" validate:"required" yaml:"content_type"`
 	Body        string `json:"body"`
 }
 
@@ -24,13 +25,22 @@ func (m CustomResponse) Value() (driver.Value, error) {
 type Source struct {
 	ID       string          `json:"id" db:"id"`
 	Name     *string         `json:"name" db:"name"`
-	Enabled  bool            `json:"enabled" db:"enabled"`
+	Enabled  bool            `json:"enabled" db:"enabled" default:"true"`
 	Path     string          `json:"path" db:"path"`
 	Methods  pq.StringArray  `json:"methods" db:"methods"`
 	Async    bool            `json:"async" db:"async"`
 	Response *CustomResponse `json:"response" db:"response"`
 
-	BaseModel
+	BaseModel `yaml:"-"`
+}
+
+func (m *Source) UnmarshalJSON(data []byte) error {
+	err := defaults.Set(m)
+	if err != nil {
+		return err
+	}
+	type alias Source
+	return json.Unmarshal(data, (*alias)(m))
 }
 
 func (m *Source) Validate() error {

--- a/db/query/querys.go
+++ b/db/query/querys.go
@@ -54,21 +54,31 @@ func (q *AttemptQuery) WhereMap() map[string]interface{} {
 
 type SourceQuery struct {
 	Query
+
+	WorkspaceId *string
 }
 
 func (q *SourceQuery) WhereMap() map[string]interface{} {
-	return map[string]interface{}{}
+	maps := make(map[string]interface{})
+	if q.WorkspaceId != nil {
+		maps["ws_id"] = *q.WorkspaceId
+	}
+	return maps
 }
 
 type PluginQuery struct {
 	Query
 
-	EndpointId *string
-	Enabled    *bool
+	WorkspaceId *string
+	EndpointId  *string
+	Enabled     *bool
 }
 
 func (q *PluginQuery) WhereMap() map[string]interface{} {
 	maps := make(map[string]interface{})
+	if q.WorkspaceId != nil {
+		maps["ws_id"] = *q.WorkspaceId
+	}
 	if q.EndpointId != nil {
 		maps["endpoint_id"] = *q.EndpointId
 	}

--- a/pkg/declarative/declarative.go
+++ b/pkg/declarative/declarative.go
@@ -1,0 +1,137 @@
+package declarative
+
+import (
+	"context"
+	"github.com/webhookx-io/webhookx/db"
+	"github.com/webhookx-io/webhookx/db/query"
+	"github.com/webhookx-io/webhookx/utils"
+)
+
+type Declarative struct {
+	db *db.DB
+}
+
+func NewDeclarative(db *db.DB) *Declarative {
+	return &Declarative{
+		db: db,
+	}
+}
+
+func (m *Declarative) Sync(wid string, cfg Configuration) error {
+	ctx := context.Background()
+
+	upsertedEndpoints := make(map[string]bool)
+	upsertedSources := make(map[string]bool)
+
+	err := m.db.TX(ctx, func(ctx context.Context) error {
+		// Endpoints
+		for _, endpoint := range cfg.Endpoints {
+			endpoint.ID = utils.KSUID()
+			endpoint.WorkspaceId = wid
+			err := m.db.Endpoints.Upsert(ctx, []string{"ws_id", "name"}, &endpoint.Endpoint)
+			if err != nil {
+				return err
+			}
+			upsertedEndpoints[endpoint.ID] = true
+
+			// Plugins
+			for _, model := range endpoint.Plugins {
+				model.ID = utils.KSUID()
+				model.WorkspaceId = wid
+				model.EndpointId = endpoint.ID
+				err = m.db.Plugins.Upsert(ctx, []string{"endpoint_id", "name"}, model)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// Sources
+		for _, source := range cfg.Sources {
+			source.ID = utils.KSUID()
+			source.WorkspaceId = wid
+			err := m.db.Sources.Upsert(ctx, []string{"ws_id", "name"}, source)
+			if err != nil {
+				return err
+			}
+			upsertedSources[source.ID] = true
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// cleanup existing endpoint
+	var endpointQ query.EndpointQuery
+	endpointQ.WorkspaceId = &wid
+	endpoints, err := m.db.Endpoints.List(ctx, &endpointQ)
+	if err != nil {
+		return err
+	}
+	for _, endpoint := range endpoints {
+		if !upsertedEndpoints[endpoint.ID] {
+			_, err := m.db.Endpoints.Delete(ctx, endpoint.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// cleanup existing source
+	var sourceQ query.SourceQuery
+	sourceQ.WorkspaceId = &wid
+	sources, err := m.db.Sources.List(ctx, &sourceQ)
+	if err != nil {
+		return err
+	}
+	for _, source := range sources {
+		if !upsertedSources[source.ID] {
+			_, err := m.db.Sources.Delete(ctx, source.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *Declarative) Dump(ctx context.Context, wid string) (*Configuration, error) {
+	var cfg Configuration
+
+	err := m.db.TX(ctx, func(ctx context.Context) error {
+		var endpointQ query.EndpointQuery
+		endpointQ.WorkspaceId = &wid
+		endpoints, err := m.db.Endpoints.List(ctx, &endpointQ)
+		if err != nil {
+			return err
+		}
+		for _, endpoint := range endpoints {
+			var e Endpoint
+			e.Endpoint = *endpoint
+			var q query.PluginQuery
+			q.EndpointId = &endpoint.ID
+			q.WorkspaceId = &endpoint.WorkspaceId
+			plugins, err := m.db.Plugins.List(ctx, &q)
+			if err != nil {
+				return err
+			}
+			e.Plugins = plugins
+			cfg.Endpoints = append(cfg.Endpoints, &e)
+		}
+
+		var sourceQ query.SourceQuery
+		sourceQ.WorkspaceId = &wid
+		sources, err := m.db.Sources.List(ctx, &sourceQ)
+		if err != nil {
+			return err
+		}
+		cfg.Sources = sources
+
+		return nil
+	})
+
+	return &cfg, err
+}

--- a/pkg/declarative/types.go
+++ b/pkg/declarative/types.go
@@ -1,0 +1,51 @@
+package declarative
+
+import (
+	"encoding/json"
+	"github.com/creasty/defaults"
+	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/pkg/plugin"
+	"github.com/webhookx-io/webhookx/utils"
+)
+
+// Configuration declarative configuration
+type Configuration struct {
+	Endpoints []*Endpoint        `json:"endpoints"`
+	Sources   []*entities.Source `json:"sources"`
+}
+
+func (m *Configuration) Validate() error {
+	err := utils.Validate(m)
+	if err != nil {
+		return err
+	}
+
+	for _, end := range m.Endpoints {
+		for _, model := range end.Plugins {
+			cfg, err := plugin.NewConfiguration(model.Name, string(model.Config))
+			if err != nil {
+				return err
+			}
+			if err := cfg.Validate(); err != nil {
+				return err
+			}
+			model.Config = utils.Must(json.Marshal(cfg))
+		}
+	}
+
+	return nil
+}
+
+type Endpoint struct {
+	entities.Endpoint `yaml:",inline"`
+	Plugins           []*entities.Plugin `json:"plugins"`
+}
+
+func (m *Endpoint) UnmarshalJSON(data []byte) error {
+	err := defaults.Set(m)
+	if err != nil {
+		return err
+	}
+	type alias Endpoint
+	return json.Unmarshal(data, (*alias)(m))
+}

--- a/pkg/plugin/init.go
+++ b/pkg/plugin/init.go
@@ -16,6 +16,23 @@ func New(name string) types.Plugin {
 	return nil
 }
 
+func NewConfiguration(name string, configuration string) (types.PluginConfig, error) {
+	instance := New(name)
+	if instance == nil {
+		return nil, errors.New("unknown plugin: " + name)
+	}
+
+	cfg := instance.Config()
+	if configuration != "" {
+		err := json.Unmarshal([]byte(configuration), cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cfg.ProcessDefault()
+	return cfg, nil
+}
+
 func ExecutePlugin(plugin *entities.Plugin, req *types.Request, ctx *types.Context) error {
 	instance := New(plugin.Name)
 	if instance == nil {

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -40,6 +40,10 @@ func (t Time) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%d", t.UnixMilli())), nil
 }
 
+func (t Time) MarshalYAML() (interface{}, error) {
+	return t.UnixMilli(), nil
+}
+
 func (t *Time) Scan(src interface{}) error {
 	if src == nil {
 		t.Time = time.Unix(0, 0)

--- a/test/admin/events_test.go
+++ b/test/admin/events_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/webhookx-io/webhookx/db/query"
 	"github.com/webhookx-io/webhookx/pkg/types"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
 	"time"
 )
@@ -125,8 +126,8 @@ var _ = Describe("/events", Ordered, func() {
 
 			BeforeAll(func() {
 				entitiesConfig := helper.EntitiesConfig{
-					Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-					Events:    []*entities.Event{helper.DefaultEvent()},
+					Endpoints: []*entities.Endpoint{factory.EndpointP()},
+					Events:    []*entities.Event{factory.EventP()},
 				}
 				endpointId = entitiesConfig.Endpoints[0].ID
 				eventId = entitiesConfig.Events[0].ID

--- a/test/admin/plugins_test.go
+++ b/test/admin/plugins_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
@@ -40,15 +41,14 @@ var _ = Describe("/plugins", Ordered, func() {
 				assert.NoError(GinkgoT(), db.Truncate("endpoints"))
 				assert.NoError(GinkgoT(), db.Truncate("plugins"))
 				for i := 1; i <= 21; i++ {
-					endpoint := helper.DefaultEndpoint()
-					endpoint.WorkspaceId = ws.ID
-					assert.NoError(GinkgoT(), db.Endpoints.Insert(context.TODO(), endpoint))
+					endpoint := factory.EndpointWS(ws.ID)
+					assert.NoError(GinkgoT(), db.Endpoints.Insert(context.TODO(), &endpoint))
 					plugin := entities.Plugin{
 						ID:         utils.KSUID(),
 						EndpointId: endpoint.ID,
 						Name:       "webhookx-signature",
 						Enabled:    true,
-						Config:     json.RawMessage("{}"),
+						Config:     entities.PluginConfiguration("{}"),
 					}
 					plugin.WorkspaceId = ws.ID
 					assert.NoError(GinkgoT(), db.Plugins.Insert(context.TODO(), &plugin))
@@ -93,7 +93,7 @@ var _ = Describe("/plugins", Ordered, func() {
 		var endpoint *entities.Endpoint
 
 		BeforeEach(func() {
-			endpoint = helper.DefaultEndpoint()
+			endpoint = factory.EndpointP()
 			assert.Nil(GinkgoT(), db.Endpoints.Insert(context.TODO(), endpoint))
 		})
 
@@ -158,14 +158,14 @@ var _ = Describe("/plugins", Ordered, func() {
 			var entity *entities.Plugin
 			BeforeAll(func() {
 				entitiesConfig := helper.EntitiesConfig{
-					Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
+					Endpoints: []*entities.Endpoint{factory.EndpointP()},
 				}
 				entity = &entities.Plugin{
 					ID:         utils.KSUID(),
 					EndpointId: entitiesConfig.Endpoints[0].ID,
 					Name:       "webhookx-signature",
 					Enabled:    true,
-					Config:     json.RawMessage(`{"signing_secret":"abcde"}`),
+					Config:     entities.PluginConfiguration(`{"signing_secret":"abcde"}`),
 				}
 				entitiesConfig.Plugins = []*entities.Plugin{entity}
 
@@ -215,7 +215,7 @@ var _ = Describe("/plugins", Ordered, func() {
 					ID:         utils.KSUID(),
 					Name:       "webhookx-signature",
 					Enabled:    true,
-					Config:     json.RawMessage("{}"),
+					Config:     entities.PluginConfiguration("{}"),
 					EndpointId: endpoint.ID,
 				}
 				plugin.WorkspaceId = ws.ID
@@ -262,7 +262,7 @@ var _ = Describe("/plugins", Ordered, func() {
 					ID:         utils.KSUID(),
 					Name:       "webhookx-signature",
 					Enabled:    true,
-					Config:     json.RawMessage("{}"),
+					Config:     entities.PluginConfiguration("{}"),
 					EndpointId: endpoint.ID,
 				}
 				entity.WorkspaceId = ws.ID

--- a/test/cmd/admin_test.go
+++ b/test/cmd/admin_test.go
@@ -161,7 +161,7 @@ var _ = Describe("admin", Ordered, func() {
 				}, ":8080")
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--timeout", "1")
 				assert.NotNil(GinkgoT(), err)
-				assert.Equal(GinkgoT(), "Error: Post \"http://localhost:8080/workspaces/default/sync\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\n", output)
+				assert.Equal(GinkgoT(), "Error: Post \"http://localhost:8080/workspaces/default/config/sync\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\n", output)
 				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
 			})
 
@@ -173,7 +173,7 @@ var _ = Describe("admin", Ordered, func() {
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--workspace", "foo")
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), "", output)
-				assert.Equal(GinkgoT(), "http://localhost:8080/workspaces/foo/sync", url)
+				assert.Equal(GinkgoT(), "http://localhost:8080/workspaces/foo/config/sync", url)
 				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
 			})
 
@@ -186,7 +186,7 @@ var _ = Describe("admin", Ordered, func() {
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--addr", "http://localhost:8888")
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), "", output)
-				assert.Equal(GinkgoT(), "http://localhost:8888/workspaces/default/sync", url)
+				assert.Equal(GinkgoT(), "http://localhost:8888/workspaces/default/config/sync", url)
 				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
 			})
 		})
@@ -234,7 +234,7 @@ var _ = Describe("admin", Ordered, func() {
 
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "dump")
 				assert.Nil(GinkgoT(), err)
-				expected, err := os.ReadFile("testdata/dump.yml")
+				expected, err := os.ReadFile("testdata/config/dump.yml")
 				require.NoError(GinkgoT(), err)
 				assert.Equal(GinkgoT(), string(expected), output)
 			})

--- a/test/cmd/admin_test.go
+++ b/test/cmd/admin_test.go
@@ -234,7 +234,7 @@ var _ = Describe("admin", Ordered, func() {
 
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "dump")
 				assert.Nil(GinkgoT(), err)
-				expected, err := os.ReadFile("testdata/config/dump.yml")
+				expected, err := os.ReadFile("testdata/dump.yml")
 				require.NoError(GinkgoT(), err)
 				assert.Equal(GinkgoT(), string(expected), output)
 			})

--- a/test/cmd/admin_test.go
+++ b/test/cmd/admin_test.go
@@ -61,7 +61,7 @@ var _ = Describe("admin", Ordered, func() {
 			It("sanity", func() {
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml")
 				assert.Nil(GinkgoT(), err)
-				assert.Equal(GinkgoT(), "", output)
+				assert.Equal(GinkgoT(), "sync successfully\n", output)
 
 				endpoint, err := db.Endpoints.Select(context.TODO(), "name", "default-endpoint")
 				assert.NoError(GinkgoT(), err)
@@ -172,7 +172,7 @@ var _ = Describe("admin", Ordered, func() {
 				}, "127.0.0.1:8080")
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--workspace", "foo")
 				assert.Nil(GinkgoT(), err)
-				assert.Equal(GinkgoT(), "", output)
+				assert.Equal(GinkgoT(), "sync successfully\n", output)
 				assert.Equal(GinkgoT(), "http://localhost:8080/workspaces/foo/config/sync", url)
 				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
 			})
@@ -185,7 +185,7 @@ var _ = Describe("admin", Ordered, func() {
 				}, "127.0.0.1:8888")
 				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--addr", "http://localhost:8888")
 				assert.Nil(GinkgoT(), err)
-				assert.Equal(GinkgoT(), "", output)
+				assert.Equal(GinkgoT(), "sync successfully\n", output)
 				assert.Equal(GinkgoT(), "http://localhost:8888/workspaces/default/config/sync", url)
 				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
 			})

--- a/test/cmd/admin_test.go
+++ b/test/cmd/admin_test.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/webhookx-io/webhookx/app"
+	"github.com/webhookx-io/webhookx/cmd"
+	"github.com/webhookx-io/webhookx/db"
+	"github.com/webhookx-io/webhookx/pkg/plugin/webhookx_signature"
+	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
+	"github.com/webhookx-io/webhookx/utils"
+	"net/http"
+	"os"
+	"time"
+)
+
+func fullURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL.Path)
+}
+
+func startHTTP(handler http.HandlerFunc, addr string) *http.Server {
+	s := &http.Server{
+		Handler: handler,
+		Addr:    addr,
+	}
+	go func() {
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("failed to start HTTP server: %s\n", err.Error())
+		}
+	}()
+	return s
+}
+
+var _ = Describe("admin", Ordered, func() {
+	Context("sync", func() {
+		Context("sanity", func() {
+			var app *app.Application
+
+			BeforeAll(func() {
+				helper.InitDB(true, nil)
+				app = utils.Must(helper.Start(map[string]string{
+					"WEBHOOKX_ADMIN_LISTEN":   "0.0.0.0:8080",
+					"WEBHOOKX_PROXY_LISTEN":   "0.0.0.0:8081",
+					"WEBHOOKX_WORKER_ENABLED": "true",
+				}))
+			})
+
+			AfterAll(func() {
+				app.Stop()
+			})
+
+			It("sanity", func() {
+				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml")
+				assert.Nil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), "", output)
+			})
+
+			Context("errors", func() {
+				It("missing filename", func() {
+					output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync")
+					assert.NotNil(GinkgoT(), err)
+					assert.Equal(GinkgoT(), "Error: accepts 1 arg(s), received 0\n", output)
+				})
+				It("invalid filename", func() {
+					output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "unknown.yaml")
+					assert.NotNil(GinkgoT(), err)
+					assert.Equal(GinkgoT(), "Error: open unknown.yaml: no such file or directory\n", output)
+				})
+				It("invalid yaml", func() {
+					output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/invalid_webhookx.yml")
+					assert.NotNil(GinkgoT(), err)
+					assert.Equal(GinkgoT(), "Error: invalid status code: 400 {\"message\":\"malformed yaml content: yaml: unmarshal errors:\\n  line 1: cannot unmarshal !!str `webhook...` into map[string]interface {}\"}\n", output)
+				})
+			})
+		})
+
+		Context("flags", Ordered, func() {
+			It("--timeout", func() {
+				server := startHTTP(func(writer http.ResponseWriter, r *http.Request) {
+					time.Sleep(time.Second * 2)
+				}, ":8080")
+				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--timeout", "1")
+				assert.NotNil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), "Error: Post \"http://localhost:8080/workspaces/default/sync\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\n", output)
+				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
+			})
+
+			It("--workspace", func() {
+				var url string
+				server := startHTTP(func(writer http.ResponseWriter, r *http.Request) {
+					url = fullURL(r)
+				}, "127.0.0.1:8080")
+				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--workspace", "foo")
+				assert.Nil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), "", output)
+				assert.Equal(GinkgoT(), "http://localhost:8080/workspaces/foo/sync", url)
+				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
+			})
+
+			It("--addr", func() {
+				time.Sleep(time.Second * 5)
+				var url string
+				server := startHTTP(func(writer http.ResponseWriter, r *http.Request) {
+					url = fullURL(r)
+				}, "127.0.0.1:8888")
+				output, err := executeCommand(cmd.NewRootCmd(), "admin", "sync", "../fixtures/webhookx.yml", "--addr", "http://localhost:8888")
+				assert.Nil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), "", output)
+				assert.Equal(GinkgoT(), "http://localhost:8888/workspaces/default/sync", url)
+				assert.Nil(GinkgoT(), server.Shutdown(context.TODO()))
+			})
+		})
+	})
+
+	Context("dump", func() {
+		Context("sanity", func() {
+			var app *app.Application
+			var db *db.DB
+
+			BeforeAll(func() {
+				db = helper.InitDB(true, nil)
+				app = utils.Must(helper.Start(map[string]string{
+					"WEBHOOKX_ADMIN_LISTEN":   "0.0.0.0:8080",
+					"WEBHOOKX_PROXY_LISTEN":   "0.0.0.0:8081",
+					"WEBHOOKX_WORKER_ENABLED": "true",
+				}))
+			})
+
+			AfterAll(func() {
+				app.Stop()
+			})
+
+			It("sanity", func() {
+				ws, err := helper.GetDeafultWorkspace()
+				assert.Nil(GinkgoT(), err)
+
+				endpoint := factory.EndpointWS(ws.ID,
+					factory.WithEndpointID("2q6ItdkHcFz8jQaXxrGp35xsShS"),
+				)
+				assert.NoError(GinkgoT(), db.Endpoints.Insert(context.TODO(), &endpoint))
+
+				source := factory.SourceWS(ws.ID,
+					factory.WithSourceID("2q6ItgNdNEIvoJ2wffn5G5j8HYC"),
+				)
+				assert.NoError(GinkgoT(), db.Sources.Insert(context.TODO(), &source))
+
+				plugin := factory.PluginWS(
+					ws.ID,
+					factory.WithPluginID("2q6ItZRVNB0EyVr6j8Pxa7VTohU"),
+					factory.WithPluginEndpointID(endpoint.ID),
+					factory.WithPluginName("webhookx-signature"),
+					factory.WithPluginConfig(&webhookx_signature.Config{SigningSecret: "test"}))
+				assert.NoError(GinkgoT(), db.Plugins.Insert(context.TODO(), &plugin))
+
+				output, err := executeCommand(cmd.NewRootCmd(), "admin", "dump")
+				assert.Nil(GinkgoT(), err)
+				expected, err := os.ReadFile("testdata/dump.yml")
+				require.NoError(GinkgoT(), err)
+				assert.Equal(GinkgoT(), string(expected), output)
+			})
+		})
+	})
+})

--- a/test/cmd/ginkgo_test.go
+++ b/test/cmd/ginkgo_test.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -17,8 +18,7 @@ func executeCommand(root *cobra.Command, args ...string) (output string, err err
 	return buf.String(), err
 }
 
-func TestCMD(t *testing.T) {
-	output, err := executeCommand(NewRootCmd(), "")
-	assert.Nil(t, err)
-	assert.NotNil(t, output)
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CMD Suite")
 }

--- a/test/cmd/testdata/dump.yml
+++ b/test/cmd/testdata/dump.yml
@@ -1,0 +1,35 @@
+endpoints:
+  - id: 2q6ItdkHcFz8jQaXxrGp35xsShS
+    name: null
+    description: null
+    enabled: true
+    request:
+      url: http://localhost:9999/anything
+      method: POST
+      headers: {}
+      timeout: 0
+    retry:
+      strategy: fixed
+      config:
+        attempts:
+          - 0
+          - 3
+          - 3
+    events:
+      - foo.bar
+    plugins:
+      - id: 2q6ItZRVNB0EyVr6j8Pxa7VTohU
+        name: webhookx-signature
+        enabled: true
+        endpoint_id: 2q6ItdkHcFz8jQaXxrGp35xsShS
+        config:
+          signing_secret: test
+sources:
+  - id: 2q6ItgNdNEIvoJ2wffn5G5j8HYC
+    name: null
+    enabled: true
+    path: /
+    methods:
+      - POST
+    async: false
+    response: null

--- a/test/cmd/version_test.go
+++ b/test/cmd/version_test.go
@@ -2,21 +2,14 @@ package cmd
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
-	"os/exec"
-	"testing"
+	"github.com/webhookx-io/webhookx/cmd"
 )
 
 var _ = Describe("version", Ordered, func() {
 	It("outputs version", func() {
-		stdout, err := exec.Command("webhookx", "version").Output()
+		output, err := executeCommand(cmd.NewRootCmd(), "version")
 		assert.Nil(GinkgoT(), err)
-		assert.Regexp(GinkgoT(), "WebhookX \\w* \\([0-9a-z]{7}\\) \n", string(stdout))
+		assert.Equal(GinkgoT(), "WebhookX dev (unknown)\n", output)
 	})
 })
-
-func TestCommandVersion(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CMD version suite")
-}

--- a/test/declarative/declarative_test.go
+++ b/test/declarative/declarative_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Declarative", Ordered, func() {
 
 			resp, err := adminClient.R().
 				SetBody(string(yaml)).
-				Post("/workspaces/default/sync")
+				Post("/workspaces/default/config/sync")
 			assert.Nil(GinkgoT(), err)
 			assert.Equal(GinkgoT(), 200, resp.StatusCode())
 		})
@@ -64,21 +64,21 @@ var _ = Describe("Declarative", Ordered, func() {
 			It("should return 400 for malformed yaml", func() {
 				resp, err := adminClient.R().
 					SetBody(malformedYAML).
-					Post("/workspaces/default/sync")
+					Post("/workspaces/default/config/sync")
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 			})
 			It("should return 400 for invalid yaml", func() {
 				resp, err := adminClient.R().
 					SetBody(invalidYAML).
-					Post("/workspaces/default/sync")
+					Post("/workspaces/default/config/sync")
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 			})
 			It("should return 400 for unknown plugin", func() {
 				resp, err := adminClient.R().
 					SetBody(unknownPluginYAML).
-					Post("/workspaces/default/sync")
+					Post("/workspaces/default/config/sync")
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 				assert.Equal(GinkgoT(), `{"message":"invalid configuration: unknown plugin: foo"}`, string(resp.Body()))

--- a/test/declarative/declarative_test.go
+++ b/test/declarative/declarative_test.go
@@ -1,49 +1,18 @@
 package declarative
 
 import (
-	"context"
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/webhookx-io/webhookx/app"
-	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/test/helper"
-	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
+	"os"
 	"testing"
 )
 
 var (
-	yaml = `
-sources:
-  - name: default-source
-    path: /
-    async: true
-    methods: [ "POST" ]
-    response:
-      code: 200
-      content_type: application/json
-      body: '{"message": "OK"}'
-
-endpoints:
-  - name: default-endpoint
-    request:
-      timeout: 10000
-      url: https://httpbin.org/anything
-      method: POST
-      headers:
-        x-apikey: secret
-    retry:
-      strategy: fixed
-      config:
-        attempts: [0, 3600, 3600]
-    events: [ "charge.succeeded" ]
-    plugins:
-      - name: webhookx-signature
-        config:
-          signing_secret: foo
-`
 	malformedYAML = `
 webhookx is coolest!
 `
@@ -66,9 +35,9 @@ endpoints:
 var _ = Describe("Declarative", Ordered, func() {
 	var app *app.Application
 	var adminClient *resty.Client
-	var db *db.DB
+
 	BeforeAll(func() {
-		db = helper.InitDB(true, nil)
+		helper.InitDB(true, nil)
 		app = utils.Must(helper.Start(map[string]string{
 			"WEBHOOKX_ADMIN_LISTEN": "0.0.0.0:8080",
 		}))
@@ -81,40 +50,14 @@ var _ = Describe("Declarative", Ordered, func() {
 
 	Context("Admin", func() {
 		It("sanity", func() {
+			yaml, err := os.ReadFile("../fixtures/webhookx.yml")
+			assert.Nil(GinkgoT(), err)
+
 			resp, err := adminClient.R().
-				SetBody(yaml).
+				SetBody(string(yaml)).
 				Post("/workspaces/default/sync")
 			assert.Nil(GinkgoT(), err)
 			assert.Equal(GinkgoT(), 200, resp.StatusCode())
-
-			endpoint, err := db.Endpoints.Select(context.TODO(), "name", "default-endpoint")
-			assert.NoError(GinkgoT(), err)
-			assert.Equal(GinkgoT(), "default-endpoint", *endpoint.Name)
-			assert.Equal(GinkgoT(), true, endpoint.Enabled)
-			assert.Equal(GinkgoT(), []string{"charge.succeeded"}, []string(endpoint.Events))
-			assert.EqualValues(GinkgoT(), 10000, endpoint.Request.Timeout)
-			assert.Equal(GinkgoT(), "https://httpbin.org/anything", endpoint.Request.URL)
-			assert.Equal(GinkgoT(), "POST", endpoint.Request.Method)
-			assert.Equal(GinkgoT(), "secret", endpoint.Request.Headers["x-apikey"])
-			assert.EqualValues(GinkgoT(), "fixed", endpoint.Retry.Strategy)
-			assert.EqualValues(GinkgoT(), []int64{0, 3600, 3600}, endpoint.Retry.Config.Attempts)
-
-			source, err := db.Sources.Select(context.TODO(), "name", "default-source")
-			assert.NoError(GinkgoT(), err)
-			assert.Equal(GinkgoT(), "default-source", *source.Name)
-			assert.Equal(GinkgoT(), true, source.Enabled)
-			assert.Equal(GinkgoT(), "/", source.Path)
-			assert.Equal(GinkgoT(), []string{"POST"}, []string(source.Methods))
-			assert.Equal(GinkgoT(), 200, source.Response.Code)
-			assert.Equal(GinkgoT(), "application/json", source.Response.ContentType)
-			assert.Equal(GinkgoT(), `{"message": "OK"}`, source.Response.Body)
-
-			plugins, err := db.Plugins.ListEndpointPlugin(context.TODO(), endpoint.ID)
-			assert.NoError(GinkgoT(), err)
-			assert.Equal(GinkgoT(), 1, len(plugins))
-			assert.Equal(GinkgoT(), "webhookx-signature", plugins[0].Name)
-			assert.Equal(GinkgoT(), true, plugins[0].Enabled)
-			assert.Equal(GinkgoT(), `{"signing_secret": "foo"}`, string(plugins[0].Config))
 		})
 
 		Context("errors", func() {
@@ -140,56 +83,6 @@ var _ = Describe("Declarative", Ordered, func() {
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 				assert.Equal(GinkgoT(), `{"message":"invalid configuration: unknown plugin: foo"}`, string(resp.Body()))
 			})
-		})
-
-		It("database entities should be deleted", func() {
-			ws, err := db.Workspaces.GetDefault(context.TODO())
-			assert.NoError(GinkgoT(), err)
-
-			endpoint := factory.EndpointWS(ws.ID)
-			err = db.Endpoints.Insert(context.TODO(), &endpoint)
-			assert.NoError(GinkgoT(), err)
-
-			source := factory.SourceP()
-			source.WorkspaceId = ws.ID
-			err = db.Sources.Insert(context.TODO(), source)
-			assert.NoError(GinkgoT(), err)
-
-			resp, err := adminClient.R().
-				SetBody(yaml).
-				Post("/workspaces/default/sync")
-			assert.Nil(GinkgoT(), err)
-			assert.Equal(GinkgoT(), 200, resp.StatusCode())
-
-			e1, err := db.Endpoints.Get(context.TODO(), endpoint.ID)
-			assert.NoError(GinkgoT(), err)
-			assert.Nil(GinkgoT(), e1)
-
-			e2, err := db.Sources.Get(context.TODO(), source.ID)
-			assert.NoError(GinkgoT(), err)
-			assert.Nil(GinkgoT(), e2)
-		})
-
-		It("id should not be changed", func() {
-			resp, err := adminClient.R().
-				SetBody(yaml).
-				Post("/workspaces/default/sync")
-			assert.Nil(GinkgoT(), err)
-			assert.Equal(GinkgoT(), 200, resp.StatusCode())
-
-			endpoint1, err := db.Endpoints.Select(context.TODO(), "name", "default-endpoint")
-			assert.NoError(GinkgoT(), err)
-
-			resp, err = adminClient.R().
-				SetBody(yaml).
-				Post("/workspaces/default/sync")
-			assert.Nil(GinkgoT(), err)
-			assert.Equal(GinkgoT(), 200, resp.StatusCode())
-
-			endpoint2, err := db.Endpoints.Select(context.TODO(), "name", "default-endpoint")
-			assert.NoError(GinkgoT(), err)
-
-			assert.Equal(GinkgoT(), endpoint1.ID, endpoint2.ID)
 		})
 	})
 })

--- a/test/declarative/declarative_test.go
+++ b/test/declarative/declarative_test.go
@@ -1,0 +1,200 @@
+package declarative
+
+import (
+	"context"
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/webhookx-io/webhookx/app"
+	"github.com/webhookx-io/webhookx/db"
+	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
+	"github.com/webhookx-io/webhookx/utils"
+	"testing"
+)
+
+var (
+	yaml = `
+sources:
+  - name: default-source
+    path: /
+    async: true
+    methods: [ "POST" ]
+    response:
+      code: 200
+      content_type: application/json
+      body: '{"message": "OK"}'
+
+endpoints:
+  - name: default-endpoint
+    request:
+      timeout: 10000
+      url: https://httpbin.org/anything
+      method: POST
+      headers:
+        x-apikey: secret
+    retry:
+      strategy: fixed
+      config:
+        attempts: [0, 3600, 3600]
+    events: [ "charge.succeeded" ]
+    plugins:
+      - name: webhookx-signature
+        config:
+          signing_secret: foo
+`
+	malformedYAML = `
+webhookx is coolest!
+`
+	invalidYAML = `
+sources:
+  - name: default-source
+    path: /
+    enabled: ok
+`
+
+	unknownPluginYAML = `
+endpoints:
+  - name: default-endpoint
+    events: [ "charge.succeeded" ]
+    plugins:
+      - name: foo
+`
+)
+
+var _ = Describe("Declarative", Ordered, func() {
+	var app *app.Application
+	var adminClient *resty.Client
+	var db *db.DB
+	BeforeAll(func() {
+		db = helper.InitDB(true, nil)
+		app = utils.Must(helper.Start(map[string]string{
+			"WEBHOOKX_ADMIN_LISTEN": "0.0.0.0:8080",
+		}))
+		adminClient = helper.AdminClient()
+	})
+
+	AfterAll(func() {
+		app.Stop()
+	})
+
+	Context("Admin", func() {
+		It("sanity", func() {
+			resp, err := adminClient.R().
+				SetBody(yaml).
+				Post("/workspaces/default/sync")
+			assert.Nil(GinkgoT(), err)
+			assert.Equal(GinkgoT(), 200, resp.StatusCode())
+
+			endpoint, err := db.Endpoints.Select(context.TODO(), "name", "default-endpoint")
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), "default-endpoint", *endpoint.Name)
+			assert.Equal(GinkgoT(), true, endpoint.Enabled)
+			assert.Equal(GinkgoT(), []string{"charge.succeeded"}, []string(endpoint.Events))
+			assert.EqualValues(GinkgoT(), 10000, endpoint.Request.Timeout)
+			assert.Equal(GinkgoT(), "https://httpbin.org/anything", endpoint.Request.URL)
+			assert.Equal(GinkgoT(), "POST", endpoint.Request.Method)
+			assert.Equal(GinkgoT(), "secret", endpoint.Request.Headers["x-apikey"])
+			assert.EqualValues(GinkgoT(), "fixed", endpoint.Retry.Strategy)
+			assert.EqualValues(GinkgoT(), []int64{0, 3600, 3600}, endpoint.Retry.Config.Attempts)
+
+			source, err := db.Sources.Select(context.TODO(), "name", "default-source")
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), "default-source", *source.Name)
+			assert.Equal(GinkgoT(), true, source.Enabled)
+			assert.Equal(GinkgoT(), "/", source.Path)
+			assert.Equal(GinkgoT(), []string{"POST"}, []string(source.Methods))
+			assert.Equal(GinkgoT(), 200, source.Response.Code)
+			assert.Equal(GinkgoT(), "application/json", source.Response.ContentType)
+			assert.Equal(GinkgoT(), `{"message": "OK"}`, source.Response.Body)
+
+			plugins, err := db.Plugins.ListEndpointPlugin(context.TODO(), endpoint.ID)
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), 1, len(plugins))
+			assert.Equal(GinkgoT(), "webhookx-signature", plugins[0].Name)
+			assert.Equal(GinkgoT(), true, plugins[0].Enabled)
+			assert.Equal(GinkgoT(), `{"signing_secret": "foo"}`, string(plugins[0].Config))
+		})
+
+		Context("errors", func() {
+			It("should return 400 for malformed yaml", func() {
+				resp, err := adminClient.R().
+					SetBody(malformedYAML).
+					Post("/workspaces/default/sync")
+				assert.Nil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), 400, resp.StatusCode())
+			})
+			It("should return 400 for invalid yaml", func() {
+				resp, err := adminClient.R().
+					SetBody(invalidYAML).
+					Post("/workspaces/default/sync")
+				assert.Nil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), 400, resp.StatusCode())
+			})
+			It("should return 400 for unknown plugin", func() {
+				resp, err := adminClient.R().
+					SetBody(unknownPluginYAML).
+					Post("/workspaces/default/sync")
+				assert.Nil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), 400, resp.StatusCode())
+				assert.Equal(GinkgoT(), `{"message":"invalid configuration: unknown plugin: foo"}`, string(resp.Body()))
+			})
+		})
+
+		It("database entities should be deleted", func() {
+			ws, err := db.Workspaces.GetDefault(context.TODO())
+			assert.NoError(GinkgoT(), err)
+
+			endpoint := factory.EndpointWS(ws.ID)
+			err = db.Endpoints.Insert(context.TODO(), &endpoint)
+			assert.NoError(GinkgoT(), err)
+
+			source := factory.SourceP()
+			source.WorkspaceId = ws.ID
+			err = db.Sources.Insert(context.TODO(), source)
+			assert.NoError(GinkgoT(), err)
+
+			resp, err := adminClient.R().
+				SetBody(yaml).
+				Post("/workspaces/default/sync")
+			assert.Nil(GinkgoT(), err)
+			assert.Equal(GinkgoT(), 200, resp.StatusCode())
+
+			e1, err := db.Endpoints.Get(context.TODO(), endpoint.ID)
+			assert.NoError(GinkgoT(), err)
+			assert.Nil(GinkgoT(), e1)
+
+			e2, err := db.Sources.Get(context.TODO(), source.ID)
+			assert.NoError(GinkgoT(), err)
+			assert.Nil(GinkgoT(), e2)
+		})
+
+		It("id should not be changed", func() {
+			resp, err := adminClient.R().
+				SetBody(yaml).
+				Post("/workspaces/default/sync")
+			assert.Nil(GinkgoT(), err)
+			assert.Equal(GinkgoT(), 200, resp.StatusCode())
+
+			endpoint1, err := db.Endpoints.Select(context.TODO(), "name", "default-endpoint")
+			assert.NoError(GinkgoT(), err)
+
+			resp, err = adminClient.R().
+				SetBody(yaml).
+				Post("/workspaces/default/sync")
+			assert.Nil(GinkgoT(), err)
+			assert.Equal(GinkgoT(), 200, resp.StatusCode())
+
+			endpoint2, err := db.Endpoints.Select(context.TODO(), "name", "default-endpoint")
+			assert.NoError(GinkgoT(), err)
+
+			assert.Equal(GinkgoT(), endpoint1.ID, endpoint2.ID)
+		})
+	})
+})
+
+func TestDeclarative(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Declarative Suite")
+}

--- a/test/delivery/delivery_test.go
+++ b/test/delivery/delivery_test.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"strconv"
 	"testing"
 	"time"
@@ -27,8 +28,8 @@ var _ = Describe("delivery", Ordered, func() {
 		var db *db.DB
 
 		entitiesConfig := helper.EntitiesConfig{
-			Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-			Sources:   []*entities.Source{helper.DefaultSource()},
+			Endpoints: []*entities.Endpoint{factory.EndpointP()},
+			Sources:   []*entities.Source{factory.SourceP()},
 		}
 		entitiesConfig.Plugins = []*entities.Plugin{{
 			ID:         utils.KSUID(),
@@ -127,13 +128,13 @@ var _ = Describe("delivery", Ordered, func() {
 
 		var app *app.Application
 		var db *db.DB
-		var endpoint = helper.DefaultEndpoint()
+		var endpoint = factory.Endpoint()
 
 		BeforeAll(func() {
 			endpoint.Request.Timeout = 1
 			entitiesConfig := helper.EntitiesConfig{
-				Endpoints: []*entities.Endpoint{endpoint},
-				Sources:   []*entities.Source{helper.DefaultSource()},
+				Endpoints: []*entities.Endpoint{&endpoint},
+				Sources:   []*entities.Source{factory.SourceP()},
 			}
 			db = helper.InitDB(true, &entitiesConfig)
 			proxyClient = helper.ProxyClient()
@@ -194,13 +195,13 @@ var _ = Describe("delivery", Ordered, func() {
 
 		var app *app.Application
 		var db *db.DB
-		var endpoint = helper.DefaultEndpoint()
+		var endpoint = factory.Endpoint()
 
 		BeforeAll(func() {
 			endpoint.Retry.Config.Attempts = []int64{3, 1, 1}
 			entitiesConfig := helper.EntitiesConfig{
-				Endpoints: []*entities.Endpoint{endpoint},
-				Sources:   []*entities.Source{helper.DefaultSource()},
+				Endpoints: []*entities.Endpoint{&endpoint},
+				Sources:   []*entities.Source{factory.SourceP()},
 			}
 			db = helper.InitDB(true, &entitiesConfig)
 			proxyClient = helper.ProxyClient()

--- a/test/fixtures/invalid_webhookx.yml
+++ b/test/fixtures/invalid_webhookx.yml
@@ -1,0 +1,1 @@
+webhookx is coolest!

--- a/test/fixtures/webhookx.yml
+++ b/test/fixtures/webhookx.yml
@@ -1,0 +1,26 @@
+endpoints:
+  - name: default-endpoint
+    request:
+      timeout: 10000
+      url: https://httpbin.org/anything
+      method: POST
+      headers:
+        x-apikey: secret
+    retry:
+      strategy: fixed
+      config:
+        attempts: [0, 3600, 3600]
+    events: [ "charge.succeeded" ]
+    plugins:
+      - name: webhookx-signature
+        config:
+          signing_secret: foo
+
+sources:
+  - name: default-source
+    path: /
+    methods: [ "POST" ]
+    response:
+      code: 200
+      content_type: application/json
+      body: '{"message": "OK"}'

--- a/test/helper/factory/factory.go
+++ b/test/helper/factory/factory.go
@@ -1,0 +1,193 @@
+package factory
+
+import (
+	"encoding/json"
+	"github.com/creasty/defaults"
+	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/utils"
+)
+
+// Endpoint
+
+func defaultEndpoint() entities.Endpoint {
+	var entity entities.Endpoint
+	entity.Init()
+	defaults.Set(&entity)
+
+	entity.Request = entities.RequestConfig{
+		URL:    "http://localhost:9999/anything",
+		Method: "POST",
+	}
+	entity.Retry.Config.Attempts = []int64{0, 3, 3}
+	entity.Events = []string{"foo.bar"}
+
+	return entity
+}
+
+type EndpointOption func(*entities.Endpoint)
+
+func WithEndpointID(id string) EndpointOption {
+	return func(e *entities.Endpoint) {
+		e.ID = id
+	}
+}
+
+func WithEndpointName(name string) EndpointOption {
+	return func(e *entities.Endpoint) {
+		e.Name = &name
+	}
+}
+
+func Endpoint(opts ...EndpointOption) entities.Endpoint {
+	e := defaultEndpoint()
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+func EndpointP(opts ...EndpointOption) *entities.Endpoint {
+	e := Endpoint(opts...)
+	return &e
+}
+
+func EndpointWS(wid string, opts ...EndpointOption) entities.Endpoint {
+	p := Endpoint(opts...)
+	p.WorkspaceId = wid
+	return p
+}
+
+// Source
+
+func defaultSource() entities.Source {
+	var entity entities.Source
+	entity.Init()
+	defaults.Set(&entity)
+
+	entity.Path = "/"
+	entity.Methods = []string{"POST"}
+
+	return entity
+}
+
+type SourceOption func(*entities.Source)
+
+func WithSourceID(id string) SourceOption {
+	return func(e *entities.Source) {
+		e.ID = id
+	}
+}
+
+func Source(opts ...SourceOption) entities.Source {
+	e := defaultSource()
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+func SourceP(opts ...SourceOption) *entities.Source {
+	e := Source(opts...)
+	return &e
+}
+
+func SourceWS(wid string, opts ...SourceOption) entities.Source {
+	p := Source(opts...)
+	p.WorkspaceId = wid
+	return p
+}
+
+// Plugin
+
+func defaultPlugin() entities.Plugin {
+	var entity entities.Plugin
+	entity.Init()
+	defaults.Set(&entity)
+	entity.Config = entities.PluginConfiguration("{}")
+
+	return entity
+}
+
+type PluginOption func(*entities.Plugin)
+
+func WithPluginID(id string) PluginOption {
+	return func(e *entities.Plugin) {
+		e.ID = id
+	}
+}
+
+func WithPluginEndpointID(endpointID string) PluginOption {
+	return func(e *entities.Plugin) {
+		e.EndpointId = endpointID
+	}
+}
+
+func WithPluginName(name string) PluginOption {
+	return func(e *entities.Plugin) {
+		e.Name = name
+	}
+}
+
+func WithPluginConfig(config interface{}) PluginOption {
+	return func(e *entities.Plugin) {
+		b, err := json.Marshal(config)
+		if err != nil {
+			panic(err)
+		}
+		e.Config = b
+	}
+}
+
+func WithPluginConfigJSON(json string) PluginOption {
+	return func(e *entities.Plugin) {
+		e.Config = entities.PluginConfiguration(json)
+	}
+}
+
+func Plugin(opts ...PluginOption) entities.Plugin {
+	e := defaultPlugin()
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+func PluginWS(wid string, opts ...PluginOption) entities.Plugin {
+	p := Plugin(opts...)
+	p.WorkspaceId = wid
+	return p
+}
+
+// Event
+
+func defaultEvent() entities.Event {
+	var entity entities.Event
+	defaults.Set(&entity)
+
+	entity.ID = utils.KSUID()
+	entity.EventType = "foo.bar"
+	entity.Data = []byte("{}")
+
+	return entity
+}
+
+type EventOption func(*entities.Event)
+
+func Event(opts ...EventOption) entities.Event {
+	e := defaultEvent()
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+func EventP(opts ...EventOption) *entities.Event {
+	e := Event(opts...)
+	return &e
+}
+
+func EventWS(wid string, opts ...EventOption) entities.Event {
+	p := Event(opts...)
+	p.WorkspaceId = wid
+	return p
+}

--- a/test/helper/factory/factory.go
+++ b/test/helper/factory/factory.go
@@ -78,6 +78,12 @@ func WithSourceID(id string) SourceOption {
 	}
 }
 
+func WithSourceAsync(async bool) SourceOption {
+	return func(e *entities.Source) {
+		e.Async = async
+	}
+}
+
 func Source(opts ...SourceOption) entities.Source {
 	e := defaultSource()
 	for _, opt := range opts {

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -5,14 +5,12 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"github.com/creasty/defaults"
 	"github.com/go-resty/resty/v2"
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/config"
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/db/migrator"
-	"github.com/webhookx-io/webhookx/utils"
 	"os"
 	"path"
 	"regexp"
@@ -186,6 +184,14 @@ func InitDB(truncated bool, entities *EntitiesConfig) *db.DB {
 	return db
 }
 
+func GetDeafultWorkspace() (*entities.Workspace, error) {
+	db, err := db.NewDB(&cfg.Database)
+	if err != nil {
+		return nil, err
+	}
+	return db.Workspaces.GetDefault(context.TODO())
+}
+
 func ResetDB() error {
 	cfg, err := config.Init()
 	if err != nil {
@@ -283,43 +289,6 @@ func FileHasLine(filename string, regex string) (bool, error) {
 	}
 
 	return false, nil
-}
-
-func DefaultEndpoint() *entities.Endpoint {
-	var entity entities.Endpoint
-	entity.Init()
-	defaults.Set(&entity)
-
-	entity.Request = entities.RequestConfig{
-		URL:    "http://localhost:9999/anything",
-		Method: "POST",
-	}
-	entity.Retry.Config.Attempts = []int64{0, 3, 3}
-	entity.Events = []string{"foo.bar"}
-
-	return &entity
-}
-
-func DefaultSource() *entities.Source {
-	var entity entities.Source
-	entity.Init()
-	defaults.Set(&entity)
-
-	entity.Path = "/"
-	entity.Methods = []string{"POST"}
-
-	return &entity
-}
-
-func DefaultEvent() *entities.Event {
-	var entity entities.Event
-	defaults.Set(&entity)
-
-	entity.ID = utils.KSUID()
-	entity.EventType = "foo.bar"
-	entity.Data = []byte("{}")
-
-	return &entity
 }
 
 func PathExist(_path string) bool {

--- a/test/metrics/opentelemetry_test.go
+++ b/test/metrics/opentelemetry_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"testing"
 	"time"
 )
@@ -27,8 +28,8 @@ var _ = Describe("opentelemetry", Ordered, func() {
 
 			BeforeAll(func() {
 				entitiesConfig := helper.EntitiesConfig{
-					Endpoints: []*entities.Endpoint{helper.DefaultEndpoint(), helper.DefaultEndpoint()},
-					Sources:   []*entities.Source{helper.DefaultSource()},
+					Endpoints: []*entities.Endpoint{factory.EndpointP(), factory.EndpointP()},
+					Sources:   []*entities.Source{factory.SourceP()},
 				}
 				entitiesConfig.Endpoints[1].Request.Timeout = 1
 				entitiesConfig.Sources[0].Async = true

--- a/test/proxy/ingest_test.go
+++ b/test/proxy/ingest_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/db/query"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
 	"time"
 )
@@ -23,8 +24,8 @@ var _ = Describe("ingest", Ordered, func() {
 		var db *db.DB
 
 		entitiesConfig := helper.EntitiesConfig{
-			Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-			Sources:   []*entities.Source{helper.DefaultSource()},
+			Endpoints: []*entities.Endpoint{factory.EndpointP()},
+			Sources:   []*entities.Source{factory.SourceP()},
 		}
 		entitiesConfig.Sources[0].Async = true
 
@@ -71,8 +72,8 @@ var _ = Describe("ingest", Ordered, func() {
 		var app *app.Application
 
 		entitiesConfig := helper.EntitiesConfig{
-			Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-			Sources:   []*entities.Source{helper.DefaultSource()},
+			Endpoints: []*entities.Endpoint{factory.EndpointP()},
+			Sources:   []*entities.Source{factory.SourceP()},
 		}
 		entitiesConfig.Sources[0].Async = true
 

--- a/test/tracing/admin_test.go
+++ b/test/tracing/admin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
 	"time"
 )
@@ -25,10 +26,9 @@ var _ = Describe("tracing admin", Ordered, func() {
 			var proxyClient *resty.Client
 			var adminClient *resty.Client
 			entitiesConfig := helper.EntitiesConfig{
-				Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-				Sources:   []*entities.Source{helper.DefaultSource()},
+				Endpoints: []*entities.Endpoint{factory.EndpointP()},
+				Sources:   []*entities.Source{factory.SourceP(factory.WithSourceAsync(true))},
 			}
-			entitiesConfig.Sources[0].Async = true
 			var gotScopeNames map[string]bool
 			var gotSpanAttributes map[string]map[string]string
 

--- a/test/tracing/ginkgo_test.go
+++ b/test/tracing/ginkgo_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
 	"go.opentelemetry.io/otel/trace"
 	"testing"
@@ -20,8 +21,8 @@ var _ = Describe("tracing disabled", Ordered, func() {
 			var app *app.Application
 
 			entitiesConfig := helper.EntitiesConfig{
-				Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-				Sources:   []*entities.Source{helper.DefaultSource()},
+				Endpoints: []*entities.Endpoint{factory.EndpointP()},
+				Sources:   []*entities.Source{factory.SourceP()},
 			}
 
 			BeforeAll(func() {

--- a/test/tracing/proxy_test.go
+++ b/test/tracing/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/webhookx-io/webhookx/config"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
 	"reflect"
 	"time"
@@ -26,8 +27,8 @@ var _ = Describe("tracing proxy", Ordered, func() {
 			var proxyClient *resty.Client
 
 			entitiesConfig := helper.EntitiesConfig{
-				Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-				Sources:   []*entities.Source{helper.DefaultSource()},
+				Endpoints: []*entities.Endpoint{factory.EndpointP()},
+				Sources:   []*entities.Source{factory.SourceP()},
 			}
 
 			BeforeAll(func() {
@@ -184,10 +185,9 @@ var _ = Describe("tracing proxy", Ordered, func() {
 		var proxyClient *resty.Client
 
 		entitiesConfig := helper.EntitiesConfig{
-			Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-			Sources:   []*entities.Source{helper.DefaultSource()},
+			Endpoints: []*entities.Endpoint{factory.EndpointP()},
+			Sources:   []*entities.Source{factory.SourceP()},
 		}
-		entitiesConfig.Sources[0].Async = false
 
 		BeforeAll(func() {
 			var err error

--- a/test/tracing/worker_test.go
+++ b/test/tracing/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
 	"time"
 )
@@ -23,8 +24,8 @@ var _ = Describe("tracing worker", Ordered, func() {
 			var app *app.Application
 			var proxyClient *resty.Client
 			entitiesConfig := helper.EntitiesConfig{
-				Endpoints: []*entities.Endpoint{helper.DefaultEndpoint()},
-				Sources:   []*entities.Source{helper.DefaultSource()},
+				Endpoints: []*entities.Endpoint{factory.EndpointP()},
+				Sources:   []*entities.Source{factory.SourceP(factory.WithSourceAsync(true))},
 			}
 			entitiesConfig.Sources[0].Async = true
 

--- a/test/worker/requeue_test.go
+++ b/test/worker/requeue_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/metrics"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/test/mocks"
 	"github.com/webhookx-io/webhookx/utils"
 	"github.com/webhookx-io/webhookx/worker"
@@ -28,7 +29,7 @@ var _ = Describe("processRequeue", Ordered, func() {
 	var ctrl *gomock.Controller
 	var queue *mocks.MockTaskQueue
 	var tracer *tracing.Tracer
-	endpoint := helper.DefaultEndpoint()
+	endpoint := factory.Endpoint()
 
 	BeforeAll(func() {
 		db = helper.InitDB(true, nil)
@@ -49,12 +50,11 @@ var _ = Describe("processRequeue", Ordered, func() {
 		// data
 		ws := utils.Must(db.Workspaces.GetDefault(context.TODO()))
 		endpoint.WorkspaceId = ws.ID
-		assert.NoError(GinkgoT(), db.Endpoints.Insert(context.TODO(), endpoint))
+		assert.NoError(GinkgoT(), db.Endpoints.Insert(context.TODO(), &endpoint))
 
 		for i := 1; i <= 10; i++ {
-			event := helper.DefaultEvent()
-			event.WorkspaceId = ws.ID
-			assert.NoError(GinkgoT(), db.Events.Insert(context.TODO(), event))
+			event := factory.EventWS(ws.ID)
+			assert.NoError(GinkgoT(), db.Events.Insert(context.TODO(), &event))
 
 			attempt := entities.Attempt{
 				ID:            utils.KSUID(),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
-import "reflect"
+import (
+	"reflect"
+)
 
 func DefaultIfZero[T any](v T, fallback T) T {
 	if reflect.ValueOf(v).IsZero() {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,8 +1,6 @@
 package utils
 
-import (
-	"reflect"
-)
+import "reflect"
 
 func DefaultIfZero[T any](v T, fallback T) T {
 	if reflect.ValueOf(v).IsZero() {

--- a/webhookx.sample.yml
+++ b/webhookx.sample.yml
@@ -1,0 +1,26 @@
+endpoints:
+  - name: default-endpoint
+    request:
+      timeout: 10000
+      url: https://httpbin.org/anything
+      method: POST
+      headers:
+        x-apikey: secret
+    retry:
+      strategy: fixed
+      config:
+        attempts: [0, 3600, 3600]
+    events: [ "charge.succeeded" ]
+    plugins:
+      - name: webhookx-signature
+        config:
+          signing_secret: foo
+
+sources:
+  - name: default-source
+    path: /
+    methods: [ "POST" ]
+    response:
+      code: 200
+      content_type: application/json
+      body: '{"message": "OK"}'

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -320,7 +320,7 @@ func (w *Worker) handleTask(ctx context.Context, task *taskqueue.TaskMessage) er
 		attemptDetail.ResponseBody = utils.Pointer(string(response.ResponseBody))
 	}
 	attemptDetail.WorkspaceId = endpoint.WorkspaceId
-	err = w.DB.AttemptDetails.Upsert(ctx, attemptDetail)
+	err = w.DB.AttemptDetails.Insert(ctx, attemptDetail)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

- Introduced declarative configuration.
- Added`admin sync` and `admin dump` commands



Usage

```
$ webhookx admin sync webhookx.sample.yml
$ # equivalent to
$ webhookx admin sync webhookx.sample.yml --timeout 10 --addr http://localhost:8080 --workspace default
```

```
$ webhookx admin dump
$ # equivalent to
$ webhookx admin dump --timeout 10 --addr http://localhost:8080 --workspace default
```