### PR TITLE
optimize: set global tracer provider as noop for better performance

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -6,11 +6,13 @@ import (
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"time"
 )
 
 func New(conf *config.TracingConfig) (*Tracer, error) {
 	if !conf.Enabled {
+		otel.SetTracerProvider(noop.NewTracerProvider())
 		return nil, nil
 	}
 

--- a/test/tracing/ginkgo_test.go
+++ b/test/tracing/ginkgo_test.go
@@ -41,7 +41,7 @@ var _ = Describe("tracing disabled", Ordered, func() {
 				app.Stop()
 			})
 
-			It("disabled tracing"+protocol, func() {
+			It("disabled tracing "+protocol, func() {
 				ctx := context.Background()
 				tCtx, span := tracing.Start(ctx, "test")
 				spanCtxValid := span.SpanContext().IsValid()


### PR DESCRIPTION
the default global tracer provider works like noop but not actually do nothing. [reference](https://github.com/open-telemetry/opentelemetry-go/discussions/3561)
```
// Tracer implements TracerProvider.
func (p *tracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
	p.mtx.Lock()
	defer p.mtx.Unlock()

	if p.delegate != nil {
		return p.delegate.Tracer(name, opts...)
	}
....
```
so replacing it by a real noop tracer provider will reduce lock and unlock cost.
