### PR TITLE
fix: remove deprecated configuration PushInterval

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -217,19 +217,6 @@ func TestMetricsConfig(t *testing.T) {
 			},
 			expectedValidateErr: errors.New("interval must be in the range [1, 60]"),
 		},
-		{
-			desc: "invalid PushInterval (Opentelemetry has higher priority)",
-			cfg: MetricsConfig{
-				Attributes:   nil,
-				Exports:      nil,
-				PushInterval: 1,
-				Opentelemetry: Opentelemetry{
-					PushInterval: 61,
-					Protocol:     "http/protobuf",
-				},
-			},
-			expectedValidateErr: errors.New("interval must be in the range [1, 60]"),
-		},
 	}
 
 	for _, test := range tests {

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -21,9 +21,6 @@ func (cfg *MetricsConfig) Validate() error {
 			return fmt.Errorf("invalid export: %s", export)
 		}
 	}
-	if cfg.Opentelemetry.PushInterval != 0 {
-		cfg.PushInterval = cfg.Opentelemetry.PushInterval
-	}
 	if cfg.PushInterval < 1 || cfg.PushInterval > 60 {
 		return fmt.Errorf("interval must be in the range [1, 60]")
 	}

--- a/config/opentelemetry.go
+++ b/config/opentelemetry.go
@@ -15,8 +15,6 @@ const (
 type Opentelemetry struct {
 	Protocol OtlpProtocol `yaml:"protocol" envconfig:"PROTOCOL" default:"http/protobuf"`
 	Endpoint string       `yaml:"endpoint" envconfig:"ENDPOINT" default:"http://localhost:4318/v1/metrics"`
-	// Deprecated: used by MetricsConfig
-	PushInterval uint32 `yaml:"push_interval" default:"10"`
 }
 
 func (cfg Opentelemetry) Validate() error {

--- a/test/admin/debug_test.go
+++ b/test/admin/debug_test.go
@@ -38,7 +38,7 @@ var _ = Describe("/debug", Ordered, func() {
 		}
 
 		for _, path := range paths {
-			resp, err := adminClient.R().Get(path + "?debug=1")
+			resp, err := adminClient.R().Get(path)
 			assert.NoError(GinkgoT(), err)
 			assert.Equal(GinkgoT(), 200, resp.StatusCode(), fmt.Sprintf("%s \n%s", path, resp.Status()))
 		}

--- a/test/metrics/opentelemetry_test.go
+++ b/test/metrics/opentelemetry_test.go
@@ -38,13 +38,13 @@ var _ = Describe("opentelemetry", Ordered, func() {
 				proxyClient = helper.ProxyClient()
 				var err error
 				app, err = helper.Start(map[string]string{
-					"WEBHOOKX_ADMIN_LISTEN":                        "0.0.0.0:8080",
-					"WEBHOOKX_PROXY_LISTEN":                        "0.0.0.0:8081",
-					"WEBHOOKX_WORKER_ENABLED":                      "true",
-					"WEBHOOKX_METRICS_EXPORTS":                     "opentelemetry",
-					"WEBHOOKX_METRICS_OPENTELEMETRY_PUSH_INTERVAL": "5",
-					"WEBHOOKX_METRICS_OPENTELEMETRY_PROTOCOL":      protocol,
-					"WEBHOOKX_METRICS_OPENTELEMETRY_ENDPOINT":      endpoints[protocol],
+					"WEBHOOKX_ADMIN_LISTEN":                   "0.0.0.0:8080",
+					"WEBHOOKX_PROXY_LISTEN":                   "0.0.0.0:8081",
+					"WEBHOOKX_WORKER_ENABLED":                 "true",
+					"WEBHOOKX_METRICS_EXPORTS":                "opentelemetry",
+					"WEBHOOKX_METRICS_PUSH_INTERVAL":          "1",
+					"WEBHOOKX_METRICS_OPENTELEMETRY_PROTOCOL": protocol,
+					"WEBHOOKX_METRICS_OPENTELEMETRY_ENDPOINT": endpoints[protocol],
 				})
 				assert.Nil(GinkgoT(), err)
 			})
@@ -126,12 +126,12 @@ var _ = Describe("opentelemetry", Ordered, func() {
 			var err error
 			helper.InitOtelOutput()
 			app, err = helper.Start(map[string]string{
-				"WEBHOOKX_METRICS_ATTRIBUTES":                  `{"env": "prod"}`,
-				"WEBHOOKX_METRICS_EXPORTS":                     "opentelemetry",
-				"WEBHOOKX_METRICS_OPENTELEMETRY_PROTOCOL":      "grpc",
-				"WEBHOOKX_METRICS_OPENTELEMETRY_ENDPOINT":      "localhost:4317",
-				"OTEL_RESOURCE_ATTRIBUTES":                     "key1=value1,key2=value2",
-				"WEBHOOKX_METRICS_OPENTELEMETRY_PUSH_INTERVAL": "5",
+				"WEBHOOKX_METRICS_ATTRIBUTES":             `{"env": "prod"}`,
+				"WEBHOOKX_METRICS_EXPORTS":                "opentelemetry",
+				"WEBHOOKX_METRICS_OPENTELEMETRY_PROTOCOL": "grpc",
+				"WEBHOOKX_METRICS_OPENTELEMETRY_ENDPOINT": "localhost:4317",
+				"OTEL_RESOURCE_ATTRIBUTES":                "key1=value1,key2=value2",
+				"WEBHOOKX_METRICS_PUSH_INTERVAL":          "1",
 			})
 			assert.Nil(GinkgoT(), err)
 		})


### PR DESCRIPTION
### Summary

- remove deprecated configuration `opentelemetry.push_internal`