### PR TITLE
feat(*): control plane and data plane

### DIFF
--- a/admin/api/api.go
+++ b/admin/api/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/http/middlewares"
 	"github.com/webhookx-io/webhookx/pkg/http/response"
 	"github.com/webhookx-io/webhookx/pkg/types"
-	"go.uber.org/zap"
 	"net/http"
 	"net/http/pprof"
 	"strconv"
@@ -20,8 +19,7 @@ import (
 
 type API struct {
 	cfg         *config.Config
-	log         *zap.SugaredLogger
-	DB          *db.DB
+	db          *db.DB
 	dispatcher  *dispatcher.Dispatcher
 	declarative *declarative.Declarative
 	bus         eventbus.Bus
@@ -39,8 +37,7 @@ type Options struct {
 func NewAPI(opts Options) *API {
 	return &API{
 		cfg:         opts.Config,
-		log:         zap.S(),
-		DB:          opts.DB,
+		db:          opts.DB,
 		dispatcher:  opts.Dispatcher,
 		declarative: declarative.NewDeclarative(opts.DB),
 		bus:         opts.EventBus,

--- a/admin/api/attempts.go
+++ b/admin/api/attempts.go
@@ -18,7 +18,7 @@ func (api *API) PageAttempt(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("endpoint_id") != "" {
 		q.EndpointId = utils.Pointer(r.URL.Query().Get("endpoint_id"))
 	}
-	list, total, err := api.DB.AttemptsWS.Page(r.Context(), &q)
+	list, total, err := api.db.AttemptsWS.Page(r.Context(), &q)
 	api.assert(err)
 
 	api.json(200, w, NewPagination(total, list))
@@ -26,7 +26,7 @@ func (api *API) PageAttempt(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) GetAttempt(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	attempt, err := api.DB.AttemptsWS.Get(r.Context(), id)
+	attempt, err := api.db.AttemptsWS.Get(r.Context(), id)
 	api.assert(err)
 
 	if attempt == nil {
@@ -35,7 +35,7 @@ func (api *API) GetAttempt(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if attempt.AttemptedAt != nil {
-		detail, err := api.DB.AttemptDetailsWS.Get(r.Context(), attempt.ID)
+		detail, err := api.db.AttemptDetailsWS.Get(r.Context(), attempt.ID)
 		api.assert(err)
 		if detail != nil {
 			if detail.RequestHeaders != nil {

--- a/admin/api/endpoints.go
+++ b/admin/api/endpoints.go
@@ -14,7 +14,7 @@ func (api *API) PageEndpoint(w http.ResponseWriter, r *http.Request) {
 	var q query.EndpointQuery
 	q.Order("id", query.DESC)
 	api.bindQuery(r, &q.Query)
-	list, total, err := api.DB.EndpointsWS.Page(r.Context(), &q)
+	list, total, err := api.db.EndpointsWS.Page(r.Context(), &q)
 	api.assert(err)
 
 	api.json(200, w, NewPagination(total, list))
@@ -22,7 +22,7 @@ func (api *API) PageEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) GetEndpoint(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	endpoint, err := api.DB.EndpointsWS.Get(r.Context(), id)
+	endpoint, err := api.db.EndpointsWS.Get(r.Context(), id)
 	api.assert(err)
 
 	if endpoint == nil {
@@ -48,7 +48,7 @@ func (api *API) CreateEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	endpoint.WorkspaceId = ucontext.GetWorkspaceID(r.Context())
-	err := api.DB.EndpointsWS.Insert(r.Context(), &endpoint)
+	err := api.db.EndpointsWS.Insert(r.Context(), &endpoint)
 	api.assert(err)
 
 	api.json(201, w, endpoint)
@@ -56,7 +56,7 @@ func (api *API) CreateEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) UpdateEndpoint(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	endpoint, err := api.DB.EndpointsWS.Get(r.Context(), id)
+	endpoint, err := api.db.EndpointsWS.Get(r.Context(), id)
 	api.assert(err)
 	if endpoint == nil {
 		api.json(404, w, types.ErrorResponse{Message: MsgNotFound})
@@ -74,7 +74,7 @@ func (api *API) UpdateEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	endpoint.ID = id
-	err = api.DB.EndpointsWS.Update(r.Context(), endpoint)
+	err = api.db.EndpointsWS.Update(r.Context(), endpoint)
 	api.assert(err)
 
 	api.json(200, w, endpoint)
@@ -82,7 +82,7 @@ func (api *API) UpdateEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) DeleteEndpoint(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	_, err := api.DB.EndpointsWS.Delete(r.Context(), id)
+	_, err := api.db.EndpointsWS.Delete(r.Context(), id)
 	api.assert(err)
 
 	w.WriteHeader(204)

--- a/admin/api/middleware.go
+++ b/admin/api/middleware.go
@@ -18,10 +18,10 @@ func (api *API) contextMiddleware(next http.Handler) http.Handler {
 			wid = "default"
 		}
 
-		workspace, err = api.DB.Workspaces.GetWorkspace(r.Context(), wid)
+		workspace, err = api.db.Workspaces.GetWorkspace(r.Context(), wid)
 		api.assert(err)
 		if workspace == nil {
-			workspace, err = api.DB.Workspaces.Get(r.Context(), wid)
+			workspace, err = api.db.Workspaces.Get(r.Context(), wid)
 			api.assert(err)
 		}
 

--- a/admin/api/plugins.go
+++ b/admin/api/plugins.go
@@ -14,7 +14,7 @@ func (api *API) PagePlugin(w http.ResponseWriter, r *http.Request) {
 	var q query.PluginQuery
 	q.Order("id", query.DESC)
 	api.bindQuery(r, &q.Query)
-	list, total, err := api.DB.PluginsWS.Page(r.Context(), &q)
+	list, total, err := api.db.PluginsWS.Page(r.Context(), &q)
 	api.assert(err)
 
 	api.json(200, w, NewPagination(total, list))
@@ -22,7 +22,7 @@ func (api *API) PagePlugin(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) GetPlugin(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	plugin, err := api.DB.PluginsWS.Get(r.Context(), id)
+	plugin, err := api.db.PluginsWS.Get(r.Context(), id)
 	api.assert(err)
 
 	if plugin == nil {
@@ -50,7 +50,7 @@ func (api *API) CreatePlugin(w http.ResponseWriter, r *http.Request) {
 	p, err := model.Plugin()
 	api.assert(err)
 	model.Config = utils.Must(p.MarshalConfig())
-	err = api.DB.PluginsWS.Insert(r.Context(), &model)
+	err = api.db.PluginsWS.Insert(r.Context(), &model)
 	api.assert(err)
 
 	api.json(201, w, model)
@@ -58,7 +58,7 @@ func (api *API) CreatePlugin(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) UpdatePlugin(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	model, err := api.DB.PluginsWS.Get(r.Context(), id)
+	model, err := api.db.PluginsWS.Get(r.Context(), id)
 	api.assert(err)
 	if model == nil {
 		api.json(404, w, types.ErrorResponse{Message: MsgNotFound})
@@ -81,7 +81,7 @@ func (api *API) UpdatePlugin(w http.ResponseWriter, r *http.Request) {
 	model.Config = utils.Must(p.MarshalConfig())
 
 	model.ID = id
-	err = api.DB.PluginsWS.Update(r.Context(), model)
+	err = api.db.PluginsWS.Update(r.Context(), model)
 	api.assert(err)
 
 	api.json(200, w, model)
@@ -89,7 +89,7 @@ func (api *API) UpdatePlugin(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) DeletePlugin(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	_, err := api.DB.PluginsWS.Delete(r.Context(), id)
+	_, err := api.db.PluginsWS.Delete(r.Context(), id)
 	api.assert(err)
 
 	w.WriteHeader(204)

--- a/admin/api/sources.go
+++ b/admin/api/sources.go
@@ -14,7 +14,7 @@ func (api *API) PageSource(w http.ResponseWriter, r *http.Request) {
 	var q query.SourceQuery
 	q.Order("id", query.DESC)
 	api.bindQuery(r, &q.Query)
-	list, total, err := api.DB.SourcesWS.Page(r.Context(), &q)
+	list, total, err := api.db.SourcesWS.Page(r.Context(), &q)
 	api.assert(err)
 
 	api.json(200, w, NewPagination(total, list))
@@ -22,7 +22,7 @@ func (api *API) PageSource(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) GetSource(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	source, err := api.DB.SourcesWS.Get(r.Context(), id)
+	source, err := api.db.SourcesWS.Get(r.Context(), id)
 	api.assert(err)
 
 	if source == nil {
@@ -48,7 +48,7 @@ func (api *API) CreateSource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	source.WorkspaceId = ucontext.GetWorkspaceID(r.Context())
-	err := api.DB.SourcesWS.Insert(r.Context(), &source)
+	err := api.db.SourcesWS.Insert(r.Context(), &source)
 	api.assert(err)
 
 	api.json(201, w, source)
@@ -56,7 +56,7 @@ func (api *API) CreateSource(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) UpdateSource(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	source, err := api.DB.SourcesWS.Get(r.Context(), id)
+	source, err := api.db.SourcesWS.Get(r.Context(), id)
 	api.assert(err)
 	if source == nil {
 		api.json(404, w, types.ErrorResponse{Message: MsgNotFound})
@@ -74,7 +74,7 @@ func (api *API) UpdateSource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	source.ID = id
-	err = api.DB.SourcesWS.Update(r.Context(), source)
+	err = api.db.SourcesWS.Update(r.Context(), source)
 	api.assert(err)
 
 	api.json(200, w, source)
@@ -82,7 +82,7 @@ func (api *API) UpdateSource(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) DeleteSource(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	_, err := api.DB.SourcesWS.Delete(r.Context(), id)
+	_, err := api.db.SourcesWS.Delete(r.Context(), id)
 	api.assert(err)
 
 	w.WriteHeader(204)

--- a/admin/api/workspaces.go
+++ b/admin/api/workspaces.go
@@ -15,7 +15,7 @@ func (api *API) PageWorkspace(w http.ResponseWriter, r *http.Request) {
 	var q query.WorkspaceQuery
 	q.Order("id", query.DESC)
 	api.bindQuery(r, &q.Query)
-	list, total, err := api.DB.Workspaces.Page(r.Context(), &q)
+	list, total, err := api.db.Workspaces.Page(r.Context(), &q)
 	api.assert(err)
 
 	api.json(200, w, NewPagination(total, list))
@@ -23,7 +23,7 @@ func (api *API) PageWorkspace(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) GetWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	workspace, err := api.DB.Workspaces.Get(r.Context(), id)
+	workspace, err := api.db.Workspaces.Get(r.Context(), id)
 	api.assert(err)
 
 	if workspace == nil {
@@ -48,7 +48,7 @@ func (api *API) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspace.ID = utils.KSUID()
-	err := api.DB.Workspaces.Insert(r.Context(), &workspace)
+	err := api.db.Workspaces.Insert(r.Context(), &workspace)
 	api.assert(err)
 
 	api.json(201, w, workspace)
@@ -56,7 +56,7 @@ func (api *API) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
-	workspace, err := api.DB.Workspaces.Get(r.Context(), id)
+	workspace, err := api.db.Workspaces.Get(r.Context(), id)
 	api.assert(err)
 	if workspace == nil {
 		api.json(404, w, types.ErrorResponse{Message: MsgNotFound})
@@ -83,7 +83,7 @@ func (api *API) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspace.ID = id
-	err = api.DB.Workspaces.Update(r.Context(), workspace)
+	err = api.db.Workspaces.Update(r.Context(), workspace)
 	api.assert(err)
 
 	api.json(200, w, workspace)
@@ -92,7 +92,7 @@ func (api *API) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 func (api *API) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := api.param(r, "id")
 
-	workspace, err := api.DB.Workspaces.Get(r.Context(), id)
+	workspace, err := api.db.Workspaces.Get(r.Context(), id)
 	api.assert(err)
 
 	if workspace != nil {
@@ -101,7 +101,7 @@ func (api *API) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		_, err = api.DB.Workspaces.Delete(r.Context(), id)
+		_, err = api.db.Workspaces.Delete(r.Context(), id)
 		api.assert(err)
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	uuid "github.com/satori/go.uuid"
 	"github.com/webhookx-io/webhookx/admin"
 	"github.com/webhookx-io/webhookx/admin/api"
 	"github.com/webhookx-io/webhookx/config"
@@ -45,6 +46,8 @@ func init() {
 }
 
 type Application struct {
+	nodeID string
+
 	cfg *config.Config
 
 	mux     sync.Mutex
@@ -66,8 +69,9 @@ type Application struct {
 
 func New(cfg *config.Config) (*Application, error) {
 	app := &Application{
-		cfg:  cfg,
-		stop: make(chan struct{}),
+		nodeID: uuid.NewV4().String(),
+		cfg:    cfg,
+		stop:   make(chan struct{}),
 	}
 
 	err := app.initialize()
@@ -300,7 +304,7 @@ func (app *Application) DB() *db.DB {
 }
 
 func (app *Application) NodeID() string {
-	return config.NODE
+	return app.nodeID
 }
 
 func (app *Application) Config() *config.Config {

--- a/config.yml
+++ b/config.yml
@@ -31,16 +31,17 @@ redis:
 #------------------------------------------------------------------------------
 # Cluster
 #------------------------------------------------------------------------------
-#role: all                          # This allows some nodes in the cluster to run as the control plane
+#role: standalone                   # Enables cluster mode.
+                                    # This allows some nodes in the cluster to run as the control plane
                                     # and others to run as the data plane.
                                     #
                                     # supported values are:
                                     #
-                                    # - `all`: this node is all-in-one node.
-                                    # - `cp`: this node runs as control plane.
+                                    # - `standalone`: disable cluster mode.
+                                    # - `cp`: this node runs as the control plane.
                                     #   It connects to the database to provide entity management.
-                                    # - `dp_proxy`: this node runs as Proxy data plane.
-                                    # - `dp_worker`: this node runs as Worker data plane.
+                                    # - `dp_proxy`: this node runs as the Proxy data plane.
+                                    # - `dp_worker`: this node runs as the Worker data plane.
 
 #------------------------------------------------------------------------------
 # ADMIN

--- a/config.yml
+++ b/config.yml
@@ -28,7 +28,19 @@ redis:
   password:
   database: 0
 
-
+#------------------------------------------------------------------------------
+# Cluster
+#------------------------------------------------------------------------------
+#role: all                          # This allows some nodes in the cluster to run as the control plane
+                                    # and others to run as the data plane.
+                                    #
+                                    # supported values are:
+                                    #
+                                    # - `all`: this node is all-in-one node.
+                                    # - `cp`: this node runs as control plane.
+                                    #   It connects to the database to provide entity management.
+                                    # - `dp_proxy`: this node runs as Proxy data plane.
+                                    # - `dp_worker`: this node runs as Worker data plane.
 
 #------------------------------------------------------------------------------
 # ADMIN

--- a/config/config.go
+++ b/config/config.go
@@ -19,10 +19,10 @@ var (
 type Role string
 
 const (
-	RoleAll      Role = "all"
-	RoleCP       Role = "cp"
-	RoleDPWorker Role = "dp_worker"
-	RoleDPProxy  Role = "dp_proxy"
+	RoleStandalone Role = "standalone"
+	RoleCP         Role = "cp"
+	RoleDPWorker   Role = "dp_worker"
+	RoleDPProxy    Role = "dp_proxy"
 )
 
 type Config struct {
@@ -36,7 +36,7 @@ type Config struct {
 	Worker    WorkerConfig    `yaml:"worker" json:"worker" envconfig:"WORKER"`
 	Metrics   MetricsConfig   `yaml:"metrics" json:"metrics" envconfig:"METRICS"`
 	Tracing   TracingConfig   `yaml:"tracing" json:"tracing" envconfig:"TRACING"`
-	Role      Role            `yaml:"role" json:"role" envconfig:"ROLE" default:"all"`
+	Role      Role            `yaml:"role" json:"role" envconfig:"ROLE" default:"standalone"`
 }
 
 func (cfg Config) String() string {
@@ -78,7 +78,7 @@ func (cfg Config) Validate() error {
 	if err := cfg.Tracing.Validate(); err != nil {
 		return err
 	}
-	if !slices.Contains([]Role{RoleAll, RoleCP, RoleDPWorker, RoleDPProxy}, cfg.Role) {
+	if !slices.Contains([]Role{RoleStandalone, RoleCP, RoleDPWorker, RoleDPProxy}, cfg.Role) {
 		return fmt.Errorf("invalid role: '%s'", cfg.Role)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/creasty/defaults"
-	uuid "github.com/satori/go.uuid"
 	"github.com/webhookx-io/webhookx/pkg/envconfig"
 	"gopkg.in/yaml.v3"
 	"io"
@@ -15,7 +14,6 @@ import (
 var (
 	VERSION = "dev"
 	COMMIT  = "unknown"
-	NODE    = uuid.NewV4().String()
 )
 
 type Role string
@@ -80,9 +78,8 @@ func (cfg Config) Validate() error {
 	if err := cfg.Tracing.Validate(); err != nil {
 		return err
 	}
-
 	if !slices.Contains([]Role{RoleAll, RoleCP, RoleDPWorker, RoleDPProxy}, cfg.Role) {
-		return fmt.Errorf("invalid role: %s", cfg.Role)
+		return fmt.Errorf("invalid role: '%s'", cfg.Role)
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -2,18 +2,29 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/creasty/defaults"
 	uuid "github.com/satori/go.uuid"
 	"github.com/webhookx-io/webhookx/pkg/envconfig"
 	"gopkg.in/yaml.v3"
 	"io"
 	"os"
+	"slices"
 )
 
 var (
 	VERSION = "dev"
 	COMMIT  = "unknown"
 	NODE    = uuid.NewV4().String()
+)
+
+type Role string
+
+const (
+	RoleAll      Role = "all"
+	RoleCP       Role = "cp"
+	RoleDPWorker Role = "dp_worker"
+	RoleDPProxy  Role = "dp_proxy"
 )
 
 type Config struct {
@@ -27,6 +38,7 @@ type Config struct {
 	Worker    WorkerConfig    `yaml:"worker" json:"worker" envconfig:"WORKER"`
 	Metrics   MetricsConfig   `yaml:"metrics" json:"metrics" envconfig:"METRICS"`
 	Tracing   TracingConfig   `yaml:"tracing" json:"tracing" envconfig:"TRACING"`
+	Role      Role            `yaml:"role" json:"role" envconfig:"ROLE" default:"all"`
 }
 
 func (cfg Config) String() string {
@@ -69,6 +81,10 @@ func (cfg Config) Validate() error {
 		return err
 	}
 
+	if !slices.Contains([]Role{RoleAll, RoleCP, RoleDPWorker, RoleDPProxy}, cfg.Role) {
+		return fmt.Errorf("invalid role: %s", cfg.Role)
+	}
+
 	return nil
 }
 
@@ -109,4 +125,25 @@ func InitWithFile(filename string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func (cfg *Config) OverrideByRole(role Role) {
+	switch role {
+	case RoleCP:
+		if cfg.Admin.Listen == "" {
+			cfg.Admin.Listen = "127.0.0.1:8080"
+		}
+		cfg.Proxy.Listen = ""
+		cfg.Worker.Enabled = false
+	case RoleDPProxy:
+		if cfg.Proxy.Listen == "" {
+			cfg.Proxy.Listen = "127.0.0.1:8081"
+		}
+		cfg.Admin.Listen = ""
+		cfg.Worker.Enabled = false
+	case RoleDPWorker:
+		cfg.Admin.Listen = ""
+		cfg.Proxy.Listen = ""
+		cfg.Worker.Enabled = true
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -338,6 +338,26 @@ func TestStatusConfig(t *testing.T) {
 	}
 }
 
+func TestRole(t *testing.T) {
+	cfg, err := Init()
+	assert.Nil(t, err)
+
+	cfg.Role = "all"
+	assert.Nil(t, cfg.Validate())
+
+	cfg.Role = "cp"
+	assert.Nil(t, cfg.Validate())
+
+	cfg.Role = "dp_worker"
+	assert.Nil(t, cfg.Validate())
+
+	cfg.Role = "dp_proxy"
+	assert.Nil(t, cfg.Validate())
+
+	cfg.Role = ""
+	assert.Equal(t, errors.New("invalid role: ''"), cfg.Validate())
+}
+
 func TestConfig(t *testing.T) {
 	cfg, err := Init()
 	assert.Nil(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -342,7 +342,7 @@ func TestRole(t *testing.T) {
 	cfg, err := Init()
 	assert.Nil(t, err)
 
-	cfg.Role = "all"
+	cfg.Role = "standalone"
 	assert.Nil(t, cfg.Validate())
 
 	cfg.Role = "cp"

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,7 +23,7 @@ const (
 )
 
 const (
-	RequeueBatch    = 100
+	RequeueBatch    = 20
 	RequeueInterval = time.Second * 60
 )
 

--- a/db/dao/attempt_dao.go
+++ b/db/dao/attempt_dao.go
@@ -60,6 +60,7 @@ func (dao *attemptDao) UpdateStatusToQueued(ctx context.Context, ids []string) e
 			"id":     ids,
 			"status": entities.AttemptStatusInit,
 		}).MustSql()
+	dao.debugSQL(sql, args)
 	_, err := dao.DB(ctx).ExecContext(ctx, sql, args...)
 	return err
 }
@@ -76,8 +77,8 @@ func (dao *attemptDao) UpdateErrorCode(ctx context.Context, id string, status en
 	return err
 }
 
-func (dao *attemptDao) ListUnqueued(ctx context.Context, limit int) (list []*entities.Attempt, err error) {
-	sql := "SELECT * FROM attempts WHERE status = 'INIT' and created_at <= now() AT TIME ZONE 'UTC' - INTERVAL '60 SECOND' limit $1"
+func (dao *attemptDao) ListUnqueuedForUpdate(ctx context.Context, limit int) (list []*entities.Attempt, err error) {
+	sql := "SELECT * FROM attempts WHERE status = 'INIT' and created_at <= now() AT TIME ZONE 'UTC' - INTERVAL '60 SECOND' limit $1 FOR UPDATE SKIP LOCKED"
 	err = dao.UnsafeDB(ctx).SelectContext(ctx, &list, sql, limit)
 	return
 }

--- a/db/dao/daos.go
+++ b/db/dao/daos.go
@@ -40,7 +40,7 @@ type AttemptDAO interface {
 	UpdateStatusToQueued(ctx context.Context, ids []string) error
 	UpdateErrorCode(ctx context.Context, id string, status entities.AttemptStatus, code entities.AttemptErrorCode) error
 	UpdateDelivery(ctx context.Context, id string, result *AttemptResult) error
-	ListUnqueued(ctx context.Context, limit int) (list []*entities.Attempt, err error)
+	ListUnqueuedForUpdate(ctx context.Context, limit int) (list []*entities.Attempt, err error)
 }
 
 type SourceDAO interface {

--- a/db/query/querys.go
+++ b/db/query/querys.go
@@ -37,6 +37,7 @@ func (q *WorkspaceQuery) WhereMap() map[string]interface{} {
 type AttemptQuery struct {
 	Query
 
+	IDs        []string
 	EventId    *string
 	EndpointId *string
 	Status     *string
@@ -44,6 +45,9 @@ type AttemptQuery struct {
 
 func (q *AttemptQuery) WhereMap() map[string]interface{} {
 	maps := make(map[string]interface{})
+	if q.IDs != nil {
+		maps["id"] = q.IDs
+	}
 	if q.EventId != nil {
 		maps["event_id"] = *q.EventId
 	}

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -82,7 +82,6 @@ func (d *Dispatcher) Dispatch(ctx context.Context, events []*entities.Event) ([]
 		if d.opts.Metrics.Enabled {
 			d.opts.Metrics.EventPersistCounter.Add(float64(n))
 		}
-		//go d.sendToQueue(context.WithoutCancel(ctx), attempts)
 	}
 	return attempts, err
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -2,18 +2,12 @@ package dispatcher
 
 import (
 	"context"
-	"github.com/webhookx-io/webhookx/constants"
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
-	"github.com/webhookx-io/webhookx/db/query"
-	"github.com/webhookx-io/webhookx/eventbus"
-	"github.com/webhookx-io/webhookx/mcache"
 	"github.com/webhookx-io/webhookx/pkg/metrics"
-	"github.com/webhookx-io/webhookx/pkg/taskqueue"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"github.com/webhookx-io/webhookx/pkg/types"
 	"github.com/webhookx-io/webhookx/utils"
-	"github.com/webhookx-io/webhookx/worker"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"time"
@@ -21,65 +15,54 @@ import (
 
 // Dispatcher is Event Dispatcher
 type Dispatcher struct {
-	log     *zap.SugaredLogger
-	queue   taskqueue.TaskQueue
-	db      *db.DB
-	metrics *metrics.Metrics
-	bus     *eventbus.EventBus
+	opts     Options
+	db       *db.DB
+	log      *zap.SugaredLogger
+	registry *Registry
 }
 
-func NewDispatcher(log *zap.SugaredLogger, queue taskqueue.TaskQueue, db *db.DB, metrics *metrics.Metrics, bus *eventbus.EventBus) *Dispatcher {
+type Options struct {
+	DB       *db.DB
+	Metrics  *metrics.Metrics
+	Registry *Registry
+}
+
+func NewDispatcher(opts Options) *Dispatcher {
 	dispatcher := &Dispatcher{
-		log:     log,
-		queue:   queue,
-		db:      db,
-		metrics: metrics,
-		bus:     bus,
+		db:       opts.DB,
+		log:      zap.S(),
+		opts:     opts,
+		registry: opts.Registry,
 	}
-	dispatcher.bus.Subscribe("endpoint.crud", func(v interface{}) {
-		data := v.(*eventbus.CrudData)
-		err := mcache.Invalidate(context.TODO(), constants.WorkspaceEndpointsKey.Build(data.WID))
-		if err != nil {
-			log.Errorf("failed to invalidate cache: key=%s %v", constants.WorkspaceEndpointsKey.Build(data.WID), err)
-		}
-	})
 	return dispatcher
 }
 
-func (d *Dispatcher) Dispatch(ctx context.Context, event *entities.Event) error {
-	return d.DispatchBatch(ctx, []*entities.Event{event})
-}
-
-func (d *Dispatcher) DispatchBatch(ctx context.Context, events []*entities.Event) error {
-	n, err := d.dispatchBatch(ctx, events)
-	if d.metrics.Enabled && err == nil {
-		d.metrics.EventPersistCounter.Add(float64(n))
-	}
-	return err
-}
-
-func (d *Dispatcher) dispatchBatch(ctx context.Context, events []*entities.Event) (int, error) {
+func (d *Dispatcher) Dispatch(ctx context.Context, events []*entities.Event) ([]*entities.Attempt, error) {
 	ctx, span := tracing.Start(ctx, "dispatcher.dispatch", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
 	if len(events) == 0 {
-		return 0, nil
+		return nil, nil
 	}
 
 	maps := make(map[string][]*entities.Attempt)
 	for _, event := range events {
-		endpoints, err := d.listSubscribedEndpoint(ctx, event.WorkspaceId, event.EventType)
+		endpoints, err := d.registry.LookUp(ctx, event)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
 		if len(endpoints) != 0 {
-			maps[event.ID] = fanout(event, endpoints, entities.AttemptTriggerModeInitial)
+			attempts := fanout(event, endpoints, entities.AttemptTriggerModeInitial)
+			maps[event.ID] = attempts
 		}
 	}
 
 	if len(maps) == 0 {
 		ids, err := d.db.Events.BatchInsertIgnoreConflict(ctx, events)
-		return len(ids), err
+		if d.opts.Metrics.Enabled {
+			d.opts.Metrics.EventPersistCounter.Add(float64(len(ids)))
+		}
+		return nil, err
 	}
 
 	attempts := make([]*entities.Attempt, 0)
@@ -96,9 +79,12 @@ func (d *Dispatcher) dispatchBatch(ctx context.Context, events []*entities.Event
 		return d.db.Attempts.BatchInsert(ctx, attempts)
 	})
 	if err == nil {
-		go d.sendToQueue(context.WithoutCancel(ctx), attempts)
+		if d.opts.Metrics.Enabled {
+			d.opts.Metrics.EventPersistCounter.Add(float64(n))
+		}
+		//go d.sendToQueue(context.WithoutCancel(ctx), attempts)
 	}
-	return n, err
+	return attempts, err
 }
 
 func fanout(event *entities.Event, endpoints []*entities.Endpoint, mode entities.AttemptTriggerMode) []*entities.Attempt {
@@ -122,82 +108,23 @@ func fanout(event *entities.Event, endpoints []*entities.Endpoint, mode entities
 	return attempts
 }
 
-func (d *Dispatcher) DispatchEndpoint(ctx context.Context, event *entities.Event, endpoints []*entities.Endpoint) error {
+func (d *Dispatcher) DispatchEndpoint(ctx context.Context, event *entities.Event, endpoints []*entities.Endpoint) ([]*entities.Attempt, error) {
 	attempts := fanout(event, endpoints, entities.AttemptTriggerModeManual)
 
 	err := d.db.Attempts.BatchInsert(ctx, attempts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	d.sendToQueue(ctx, attempts)
-
-	return nil
+	return attempts, nil
 }
 
-func (d *Dispatcher) sendToQueue(ctx context.Context, attempts []*entities.Attempt) {
-	tasks := make([]*taskqueue.TaskMessage, 0, len(attempts))
-	ids := make([]string, 0, len(attempts))
-	for _, attempt := range attempts {
-		tasks = append(tasks, &taskqueue.TaskMessage{
-			ID:          attempt.ID,
-			ScheduledAt: attempt.ScheduledAt.Time,
-			Data: &worker.MessageData{
-				EventID:    attempt.EventId,
-				EndpointId: attempt.EndpointId,
-				Attempt:    attempt.AttemptNumber,
-				Event:      string(attempt.Event.Data),
-			},
-		})
-		ids = append(ids, attempt.ID)
-	}
-
-	err := d.queue.Add(ctx, tasks)
+func (d *Dispatcher) WarmUp() {
+	t := time.Now()
+	err := d.registry.Warmup()
 	if err != nil {
-		d.log.Warnf("failed to add tasks to queue: %v", err)
+		d.log.Warnf("failed to warm-up: %v", err)
 		return
 	}
-	err = d.db.Attempts.UpdateStatusToQueued(ctx, ids)
-	if err != nil {
-		d.log.Warnf("failed to update attempts status: %v", err)
-	}
-}
-
-func (d *Dispatcher) listSubscribedEndpoint(ctx context.Context, wid, eventType string) (list []*entities.Endpoint, err error) {
-	endpoints, err := listWorkspaceEndpoints(ctx, d.db, wid)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, endpoint := range endpoints {
-		if !endpoint.Enabled {
-			continue
-		}
-		for _, event := range endpoint.Events {
-			if eventType == event {
-				list = append(list, endpoint)
-			}
-		}
-	}
-
-	return
-}
-
-func listWorkspaceEndpoints(ctx context.Context, db *db.DB, wid string) ([]*entities.Endpoint, error) {
-	// refactor me
-	cacheKey := constants.WorkspaceEndpointsKey.Build(wid)
-	endpoints, err := mcache.Load(ctx, cacheKey, nil, func(ctx context.Context, id string) (*[]*entities.Endpoint, error) {
-		var q query.EndpointQuery
-		q.WorkspaceId = &wid
-		q.Enabled = utils.Pointer(true)
-		endpoints, err := db.Endpoints.List(ctx, &q)
-		if err != nil {
-			return nil, err
-		}
-		return &endpoints, nil
-	}, wid)
-	if err != nil {
-		return nil, err
-	}
-	return *endpoints, err
+	d.log.Debugf("warm-up finished in %dms", time.Since(t).Milliseconds())
 }

--- a/dispatcher/registration.go
+++ b/dispatcher/registration.go
@@ -1,0 +1,25 @@
+package dispatcher
+
+import "github.com/webhookx-io/webhookx/db/entities"
+
+type Registration struct {
+	static map[string][]*entities.Endpoint
+}
+
+func NewRegistration(endpoints []*entities.Endpoint) *Registration {
+	r := &Registration{
+		static: make(map[string][]*entities.Endpoint),
+	}
+
+	for _, endpoint := range endpoints {
+		for _, event := range endpoint.Events {
+			r.static[event] = append(r.static[event], endpoint)
+		}
+	}
+	return r
+}
+
+func (r *Registration) LookUp(event *entities.Event) []*entities.Endpoint {
+	matched := r.static[event.EventType]
+	return matched
+}

--- a/dispatcher/registry.go
+++ b/dispatcher/registry.go
@@ -1,0 +1,84 @@
+package dispatcher
+
+import (
+	"context"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/webhookx-io/webhookx/db"
+	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/db/query"
+	"github.com/webhookx-io/webhookx/utils"
+	"golang.org/x/sync/singleflight"
+	"time"
+)
+
+type Registry struct {
+	group singleflight.Group
+	lru   *expirable.LRU[string, *Registration]
+	db    *db.DB
+}
+
+func NewRegistry(db *db.DB) *Registry {
+	return &Registry{
+		lru: expirable.NewLRU[string, *Registration](100, nil, time.Second*60),
+		db:  db,
+	}
+}
+
+func (r *Registry) Warmup() error {
+	workspaces, err := r.db.Workspaces.List(context.TODO(), &query.WorkspaceQuery{})
+	if err != nil {
+		return err
+	}
+
+	for _, w := range workspaces {
+		v, err := r.load(context.TODO(), w.ID)
+		if err != nil {
+			return err
+		}
+		r.lru.Add(w.ID, v)
+	}
+
+	return nil
+}
+
+func (r *Registry) load(ctx context.Context, wid string) (*Registration, error) {
+	var q query.EndpointQuery
+	q.WorkspaceId = &wid
+	q.Enabled = utils.Pointer(true)
+	endpoints, err := r.db.Endpoints.List(ctx, &q)
+	if err != nil {
+		return nil, err
+	}
+	return NewRegistration(endpoints), nil
+}
+
+func (r *Registry) Unregister(wid string) {
+	r.lru.Remove(wid)
+}
+
+func (r *Registry) LookUp(ctx context.Context, event *entities.Event) ([]*entities.Endpoint, error) {
+	wid := event.WorkspaceId
+	registration, exist := r.lru.Get(wid)
+	if !exist {
+		_, err, _ := r.group.Do(wid, func() (interface{}, error) {
+			v, err := r.load(ctx, wid)
+			if err != nil {
+				return nil, err
+			}
+			r.lru.Add(wid, v)
+			return nil, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		registration, _ = r.lru.Get(wid)
+	}
+
+	if registration == nil {
+		return nil, nil
+	}
+
+	return registration.LookUp(event), nil
+}

--- a/docker-compose-clustering.yml
+++ b/docker-compose-clustering.yml
@@ -1,0 +1,87 @@
+services:
+  postgres:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: webhookx
+      POSTGRES_USER: webhookx
+      POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
+      interval: 3s
+      timeout: 5s
+      retries: 3
+
+  redis:
+    image: redis:6.2
+    command: "--appendonly yes --appendfsync everysec"
+
+  webhookx-migration:
+    image: "webhookx/webhookx:0.8.0"
+    container_name: webhookx-migration
+    environment:
+      WEBHOOKX_DATABASE_HOST: postgres
+      WEBHOOKX_DATABASE_USERNAME: webhookx
+      WEBHOOKX_DATABASE_DATABASE: webhookx
+      WEBHOOKX_DATABASE_PORT: 5432
+    command: webhookx migrations up
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  webhookx-cp:
+    image: "webhookx/webhookx:0.8.0"
+    environment:
+      WEBHOOKX_DATABASE_HOST: postgres
+      WEBHOOKX_DATABASE_USERNAME: webhookx
+      WEBHOOKX_DATABASE_DATABASE: webhookx
+      WEBHOOKX_DATABASE_PORT: 5432
+      WEBHOOKX_ADMIN_LISTEN: 0.0.0.0:8080
+      WEBHOOKX_ROLE: cp
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      webhookx-migration:
+        condition: service_started
+
+  webhookx-dp-gateway:
+    image: "webhookx/webhookx:0.8.0"
+    environment:
+      WEBHOOKX_DATABASE_HOST: postgres
+      WEBHOOKX_DATABASE_USERNAME: webhookx
+      WEBHOOKX_DATABASE_DATABASE: webhookx
+      WEBHOOKX_DATABASE_PORT: 5432
+      WEBHOOKX_REDIS_HOST: redis
+      WEBHOOKX_REDIS_PORT: 6379
+      WEBHOOKX_PROXY_LISTEN: 0.0.0.0:8081
+      WEBHOOKX_PROXY_QUEUE_REDIS_HOST: redis
+      WEBHOOKX_PROXY_QUEUE_REDIS_PORT: 6379
+      WEBHOOKX_ROLE: dp_proxy
+    ports:
+      - "8081:8081"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      webhookx-migration:
+        condition: service_started
+
+  webhookx-dp-worker:
+    image: "webhookx/webhookx:0.8.0"
+    environment:
+      WEBHOOKX_DATABASE_HOST: postgres
+      WEBHOOKX_DATABASE_USERNAME: webhookx
+      WEBHOOKX_DATABASE_DATABASE: webhookx
+      WEBHOOKX_DATABASE_PORT: 5432
+      WEBHOOKX_REDIS_HOST: redis
+      WEBHOOKX_REDIS_PORT: 6379
+      WEBHOOKX_ROLE: dp_worker
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      webhookx-migration:
+        condition: service_started

--- a/eventbus/eventbus.go
+++ b/eventbus/eventbus.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/lib/pq"
-	"github.com/webhookx-io/webhookx/config"
 	"go.uber.org/zap"
 	"sync"
 	"time"
@@ -108,7 +107,7 @@ func (bus *EventBus) ClusteringBroadcast(channel string, data interface{}) error
 	msg := Message{
 		Event: channel,
 		Time:  time.Now().UnixMilli(),
-		Node:  config.NODE,
+		Node:  bus.nodeID,
 		Data:  bytes,
 	}
 	bytes, err = json.Marshal(msg)

--- a/eventbus/types.go
+++ b/eventbus/types.go
@@ -3,7 +3,8 @@ package eventbus
 import "encoding/json"
 
 const (
-	EventCRUD = "crud"
+	EventCRUD        = "crud"
+	EventEventFanout = "event.fanout"
 )
 
 type Bus interface {
@@ -21,6 +22,8 @@ type Message struct {
 	Data  json.RawMessage `json:"data"`
 }
 
+type Callback func(data interface{})
+
 type CrudData struct {
 	Entity   string          `json:"entity"`
 	ID       string          `json:"id"`
@@ -29,4 +32,7 @@ type CrudData struct {
 	Data     json.RawMessage `json:"data"`
 }
 
-type Callback func(data interface{})
+type EventFanoutData struct {
+	EventId    string   `json:"event_id"`
+	AttemptIds []string `json:"attempt_ids"`
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
 	github.com/go-kit/kit v0.13.0
 	github.com/go-playground/validator/v10 v10.26.0
+	github.com/go-redsync/redsync/v4 v4.13.0
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/gorilla/mux v1.8.1
@@ -38,6 +39,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
 	go.uber.org/mock v0.5.2
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.14.0
 	google.golang.org/grpc v1.72.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -59,7 +61,6 @@ require (
 	go.opentelemetry.io/contrib/propagators/jaeger v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.36.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,14 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc/iMaVtFbr3Sw2k=
 github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis/v7 v7.4.1 h1:PASvf36gyUpr2zdOUS/9Zqc80GbM+9BDyiJSJDDOrTI=
+github.com/go-redis/redis/v7 v7.4.1/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
+github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
+github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
+github.com/go-redsync/redsync/v4 v4.13.0 h1:49X6GJfnbLGaIpBBREM/zA4uIMDXKAh1NDkvQ1EkZKA=
+github.com/go-redsync/redsync/v4 v4.13.0/go.mod h1:HMW4Q224GZQz6x1Xc7040Yfgacukdzu7ifTDAKiyErQ=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
@@ -78,6 +86,8 @@ github.com/golang-migrate/migrate/v4 v4.18.3 h1:EYGkoOsvgHHfm5U/naS1RP/6PL/Xv3S4
 github.com/golang-migrate/migrate/v4 v4.18.3/go.mod h1:99BKpIi6ruaaXRM1A77eqZ+FWPQ3cfRa+ZVy5bmWMaY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gomodule/redigo v1.8.9 h1:Sl3u+2BI/kk+VEatbj0scLdrFhjPmbxOc1myhDP41ws=
+github.com/gomodule/redigo v1.8.9/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs06a1uzZE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
@@ -149,6 +159,8 @@ github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=
 github.com/redis/go-redis/v9 v9.8.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/redis/rueidis v1.0.19 h1:s65oWtotzlIFN8eMPhyYwxlwLR1lUdhza2KtWprKYSo=
+github.com/redis/rueidis v1.0.19/go.mod h1:8B+r5wdnjwK3lTFml5VtxjzGOQAC+5UmujoD12pDrEo=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
@@ -169,6 +181,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
+github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/mcache/mcache.go
+++ b/mcache/mcache.go
@@ -48,6 +48,9 @@ func (c *MCache) InvalidateL1(ctx context.Context, key string) error {
 }
 
 func (c *MCache) InvalidateL2(ctx context.Context, key string) error {
+	if c.l2 == nil {
+		return nil
+	}
 	return c.l2.Remove(ctx, key)
 }
 

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -6,9 +6,10 @@ import (
 )
 
 func Schedule(ctx context.Context, fn func(), interval time.Duration) {
-	ticker := time.NewTicker(interval)
-
 	go func() {
+		fn()
+
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/pkg/taskqueue/types.go
+++ b/pkg/taskqueue/types.go
@@ -1,4 +1,4 @@
-package worker
+package taskqueue
 
 type MessageData struct {
 	EventID    string `json:"event_id"`

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+	"github.com/webhookx-io/webhookx/db"
+	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/pkg/taskqueue"
+	"go.uber.org/zap"
+)
+
+type Service struct {
+	log   *zap.SugaredLogger
+	db    *db.DB
+	queue taskqueue.TaskQueue
+}
+
+type Options struct {
+	DB        *db.DB
+	TaskQueue taskqueue.TaskQueue
+}
+
+func NewService(opts Options) *Service {
+	return &Service{
+		log:   zap.S(),
+		db:    opts.DB,
+		queue: opts.TaskQueue,
+	}
+}
+
+func (s *Service) ScheduleAttempts(ctx context.Context, attempts []*entities.Attempt) {
+	if len(attempts) == 0 {
+		return
+	}
+
+	tasks := make([]*taskqueue.TaskMessage, 0)
+	ids := make([]string, 0)
+	for _, attempt := range attempts {
+		tasks = append(tasks, &taskqueue.TaskMessage{
+			ID:          attempt.ID,
+			ScheduledAt: attempt.ScheduledAt.Time,
+			Data: &taskqueue.MessageData{
+				EventID:    attempt.EventId,
+				EndpointId: attempt.EndpointId,
+				Attempt:    attempt.AttemptNumber,
+				Event:      string(attempt.Event.Data),
+			},
+		})
+		ids = append(ids, attempt.ID)
+	}
+
+	if len(tasks) == 0 {
+		return
+	}
+
+	err := s.queue.Add(ctx, tasks)
+	if err != nil {
+		s.log.Warnf("failed to add tasks to queue: %v", err)
+		return
+	}
+	err = s.db.Attempts.UpdateStatusToQueued(ctx, ids)
+	if err != nil {
+		s.log.Warnf("failed to update attempts status: %v", err)
+	}
+}
+
+func (s *Service) GetTasks(ctx context.Context, opts *taskqueue.GetOptions) ([]*taskqueue.TaskMessage, error) {
+	return s.queue.Get(ctx, opts)
+}
+
+func (s *Service) DeleteTask(ctx context.Context, task *taskqueue.TaskMessage) error {
+	return s.queue.Delete(ctx, task)
+}

--- a/test/admin/events_test.go
+++ b/test/admin/events_test.go
@@ -192,7 +192,7 @@ var _ = Describe("/events", Ordered, func() {
 				assert.NoError(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 1, len(attempts))
 				assert.Equal(GinkgoT(), entities.AttemptTriggerModeManual, attempts[0].TriggerMode)
-				assert.Equal(GinkgoT(), entities.AttemptStatusQueued, attempts[0].Status)
+				assert.Equal(GinkgoT(), entities.AttemptStatusInit, attempts[0].Status)
 			})
 
 			Context("errors", func() {

--- a/test/admin/events_test.go
+++ b/test/admin/events_test.go
@@ -96,6 +96,8 @@ var _ = Describe("/events", Ordered, func() {
 			assert.NotEmpty(GinkgoT(), result.ID)
 			assert.Equal(GinkgoT(), "foo.bar", result.EventType)
 			assert.Equal(GinkgoT(), `{"key":"value"}`, string(result.Data))
+			assert.True(GinkgoT(), result.CreatedAt.Unix() > 0)
+			assert.True(GinkgoT(), result.UpdatedAt.Unix() > 0)
 		})
 
 		Context("errors", func() {

--- a/test/clustering/clustering_test.go
+++ b/test/clustering/clustering_test.go
@@ -1,0 +1,131 @@
+package clustering
+
+import (
+	"context"
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/webhookx-io/webhookx/app"
+	"github.com/webhookx-io/webhookx/db"
+	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/db/query"
+	"github.com/webhookx-io/webhookx/test/helper"
+	"github.com/webhookx-io/webhookx/test/helper/factory"
+	"github.com/webhookx-io/webhookx/utils"
+	"testing"
+	"time"
+)
+
+var _ = Describe("clustering", Ordered, func() {
+
+	Context("clustering", func() {
+		var adminClient *resty.Client
+		var proxyClient *resty.Client
+
+		var cp *app.Application
+		var worker1 *app.Application
+		var worker2 *app.Application
+		var proxy *app.Application
+		var db *db.DB
+
+		entitiesConfig := helper.EntitiesConfig{
+			Endpoints: []*entities.Endpoint{factory.EndpointP()},
+			Sources:   []*entities.Source{factory.SourceP()},
+		}
+
+		BeforeAll(func() {
+			db = helper.InitDB(true, &entitiesConfig)
+			adminClient = helper.AdminClient()
+			proxyClient = helper.ProxyClient()
+
+			cp = utils.Must(helper.Start(map[string]string{
+				"WEBHOOKX_STATUS_LISTEN": "off",
+				"WEBHOOKX_ROLE":          "cp",
+				"WEBHOOKX_LOG_FILE":      "webhookx-cp.log",
+			}))
+			worker1 = utils.Must(helper.Start(map[string]string{
+				"WEBHOOKX_STATUS_LISTEN": "off",
+				"WEBHOOKX_ROLE":          "dp_worker",
+				"WEBHOOKX_LOG_FILE":      "webhookx-worker1.log",
+			}))
+			worker2 = utils.Must(helper.Start(map[string]string{
+				"WEBHOOKX_STATUS_LISTEN": "off",
+				"WEBHOOKX_ROLE":          "dp_worker",
+				"WEBHOOKX_LOG_FILE":      "webhookx-worker2.log",
+			}))
+			proxy = utils.Must(helper.Start(map[string]string{
+				"WEBHOOKX_STATUS_LISTEN": "off",
+				"WEBHOOKX_ROLE":          "dp_proxy",
+				"WEBHOOKX_LOG_FILE":      "webhookx-proxy.log",
+			}))
+		})
+
+		BeforeEach(func() {
+			err := db.Truncate("events")
+			assert.Nil(GinkgoT(), err)
+		})
+
+		AfterAll(func() {
+			cp.Stop()
+			worker1.Stop()
+			worker2.Stop()
+			proxy.Stop()
+		})
+
+		It("events created from admin API must be delivered", func() {
+			for i := 0; i < 100; i++ {
+				resp, err := adminClient.R().
+					SetBody(`{
+				    "event_type": "foo.bar",
+				    "data": {"key":"value"}
+				}`).
+					SetResult(entities.Event{}).
+					Post("/workspaces/default/events")
+				assert.Nil(GinkgoT(), err)
+				assert.Equal(GinkgoT(), 201, resp.StatusCode())
+				result := resp.Result().(*entities.Event)
+				assert.NotEmpty(GinkgoT(), result.ID)
+				assert.Equal(GinkgoT(), "foo.bar", result.EventType)
+				assert.Equal(GinkgoT(), `{"key":"value"}`, string(result.Data))
+			}
+
+			assert.Eventually(GinkgoT(), func() bool {
+				q := query.AttemptQuery{
+					Status: utils.Pointer(entities.AttemptStatusSuccess),
+				}
+
+				n, err := db.Attempts.Count(context.TODO(), q.WhereMap())
+				assert.NoError(GinkgoT(), err)
+				return n == 100
+			}, time.Second*3, time.Second)
+		})
+
+		It("events ingested from proxy API must be delivered", func() {
+			resp, err := proxyClient.R().
+				SetBody(`{
+					    "event_type": "foo.bar",
+					    "data": {"key": "value"}
+					}`).
+				Post("/")
+			assert.Nil(GinkgoT(), err)
+			assert.Equal(GinkgoT(), 200, resp.StatusCode())
+
+			var attempt *entities.Attempt
+			assert.Eventually(GinkgoT(), func() bool {
+				list, err := db.Attempts.List(context.TODO(), &query.AttemptQuery{})
+				if err != nil || len(list) == 0 {
+					return false
+				}
+				attempt = list[0]
+				return attempt.Status == entities.AttemptStatusSuccess
+			}, time.Second*3, time.Second)
+		})
+
+	})
+})
+
+func TestClustering(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Clustering Suite")
+}

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"github.com/go-resty/resty/v2"
+	uuid "github.com/satori/go.uuid"
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/config"
 	"github.com/webhookx-io/webhookx/db"
@@ -124,16 +125,16 @@ func DB() *db.DB {
 	if err != nil {
 		return nil
 	}
-	log1, err := log.NewZapLogger(&cfg.Log)
+	logger, err := log.NewZapLogger(&cfg.Log)
 	if err != nil {
 		return nil
 	}
 	eventbus := eventbus.NewEventBus(
-		config.NODE,
+		uuid.NewV4().String(),
 		cfg.Database.GetDSN(),
-		log1, sqlDB)
+		logger, sqlDB)
 
-	db, err := db.NewDB(sqlDB, log1, eventbus)
+	db, err := db.NewDB(sqlDB, logger, eventbus)
 	if err != nil {
 		return nil
 	}

--- a/test/tracing/proxy_test.go
+++ b/test/tracing/proxy_test.go
@@ -89,7 +89,6 @@ var _ = Describe("tracing proxy", Ordered, func() {
 					"api.proxy":                 entrypoint,
 					"proxy.handle":              router,
 					"dispatcher.dispatch":       {},
-					"dao.endpoints.list":        {},
 					"db.transaction":            {},
 					"dao.attempts.batch_insert": {},
 					"taskqueue.redis.add":       {},


### PR DESCRIPTION
### Summary

This PR introduced cluster mode -- Control Plane (CP) and Data Plane (DP).

The `role` configuration indicates which role the current node runs as.

- `standalone`: this disables cluster mode. (by default)
- `cp`: this node runs as the control plane.  It connects to the database to provide entity management.
- `dp_proxy`: this node runs as the Proxy data plane.
- `dp_worker`: this node runs as the Worker data plane.

A cluster can have any number of CPs and any number of DPs.

#### Role functionality

- Control Plane: Exposes admin API for entity management.
- Proxy Data Plane: Expose proxy API for ingesting events and scheduling tasks.
- Worker Data Plane: Delivery webhooks.


#### Role dependencies:
- `standalone`: database, redis
- `cp`: database
- `dp_proxy`: database, redis
- `dp_worker`: database, redis
