### PR TITLE
fix(config): fix invalid default value

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -176,7 +176,7 @@ func TestMetricsConfig(t *testing.T) {
 				Attributes:   nil,
 				Exports:      nil,
 				PushInterval: 1,
-				Opentelemetry: Opentelemetry{
+				Opentelemetry: OpentelemetryMetrics{
 					Protocol: "http/protobuf",
 				},
 			},
@@ -188,7 +188,7 @@ func TestMetricsConfig(t *testing.T) {
 				Attributes:   nil,
 				Exports:      []Export{"unknown"},
 				PushInterval: 1,
-				Opentelemetry: Opentelemetry{
+				Opentelemetry: OpentelemetryMetrics{
 					Protocol: "http/protobuf",
 				},
 			},
@@ -200,7 +200,7 @@ func TestMetricsConfig(t *testing.T) {
 				Attributes:   nil,
 				Exports:      nil,
 				PushInterval: 1,
-				Opentelemetry: Opentelemetry{
+				Opentelemetry: OpentelemetryMetrics{
 					Protocol: "unknown",
 				},
 			},
@@ -212,7 +212,7 @@ func TestMetricsConfig(t *testing.T) {
 				Attributes:   nil,
 				Exports:      nil,
 				PushInterval: 61,
-				Opentelemetry: Opentelemetry{
+				Opentelemetry: OpentelemetryMetrics{
 					Protocol: "http/protobuf",
 				},
 			},
@@ -237,7 +237,7 @@ func TestTracingConfig(t *testing.T) {
 			cfg: TracingConfig{
 				Enabled:      true,
 				SamplingRate: 0,
-				Opentelemetry: Opentelemetry{
+				Opentelemetry: OpentelemetryTracing{
 					Protocol: "http/protobuf",
 					Endpoint: "http://localhost:4318/v1/traces",
 				},
@@ -249,7 +249,7 @@ func TestTracingConfig(t *testing.T) {
 			cfg: TracingConfig{
 				Enabled:      true,
 				SamplingRate: 1.1,
-				Opentelemetry: Opentelemetry{
+				Opentelemetry: OpentelemetryTracing{
 					Protocol: "http/protobuf",
 					Endpoint: "http://localhost:4318/v1/traces",
 				},
@@ -259,7 +259,7 @@ func TestTracingConfig(t *testing.T) {
 		{
 			desc: "invalid protocol",
 			cfg: TracingConfig{
-				Opentelemetry: Opentelemetry{
+				Opentelemetry: OpentelemetryTracing{
 					Protocol: "unknown",
 				},
 			},

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -6,10 +6,22 @@ import (
 )
 
 type MetricsConfig struct {
-	Attributes    Map           `yaml:"attributes" json:"attributes"`
-	Exports       []Export      `yaml:"exports" json:"exports"`
-	PushInterval  uint32        `yaml:"push_interval" json:"push_interval" default:"10" envconfig:"PUSH_INTERVAL"`
-	Opentelemetry Opentelemetry `yaml:"opentelemetry" json:"opentelemetry"`
+	Attributes    Map                  `yaml:"attributes" json:"attributes"`
+	Exports       []Export             `yaml:"exports" json:"exports"`
+	PushInterval  uint32               `yaml:"push_interval" json:"push_interval" default:"10" envconfig:"PUSH_INTERVAL"`
+	Opentelemetry OpentelemetryMetrics `yaml:"opentelemetry" json:"opentelemetry"`
+}
+
+type OpentelemetryMetrics struct {
+	Protocol OtlpProtocol `yaml:"protocol" json:"protocol" envconfig:"PROTOCOL" default:"http/protobuf"`
+	Endpoint string       `yaml:"endpoint" json:"endpoint" envconfig:"ENDPOINT" default:"http://localhost:4318/v1/metrics"`
+}
+
+func (cfg OpentelemetryMetrics) Validate() error {
+	if !slices.Contains([]OtlpProtocol{OtlpProtocolGRPC, OtlpProtocolHTTP}, cfg.Protocol) {
+		return fmt.Errorf("invalid protocol: %s", cfg.Protocol)
+	}
+	return nil
 }
 
 func (cfg *MetricsConfig) Validate() error {

--- a/config/opentelemetry.go
+++ b/config/opentelemetry.go
@@ -1,25 +1,8 @@
 package config
 
-import (
-	"fmt"
-	"slices"
-)
-
 type OtlpProtocol string
 
 const (
 	OtlpProtocolGRPC OtlpProtocol = "grpc"
 	OtlpProtocolHTTP OtlpProtocol = "http/protobuf"
 )
-
-type Opentelemetry struct {
-	Protocol OtlpProtocol `yaml:"protocol" json:"protocol" envconfig:"PROTOCOL" default:"http/protobuf"`
-	Endpoint string       `yaml:"endpoint" json:"endpoint" envconfig:"ENDPOINT" default:"http://localhost:4318/v1/metrics"`
-}
-
-func (cfg Opentelemetry) Validate() error {
-	if !slices.Contains([]OtlpProtocol{OtlpProtocolGRPC, OtlpProtocolHTTP}, cfg.Protocol) {
-		return fmt.Errorf("invalid protocol: %s", cfg.Protocol)
-	}
-	return nil
-}

--- a/config/tracing.go
+++ b/config/tracing.go
@@ -2,13 +2,27 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"slices"
 )
 
 type TracingConfig struct {
-	Enabled       bool          `yaml:"enabled" json:"enabled" default:"false"`
-	Attributes    Map           `yaml:"attributes" json:"attributes"`
-	Opentelemetry Opentelemetry `yaml:"opentelemetry" json:"opentelemetry"`
-	SamplingRate  float64       `yaml:"sampling_rate" json:"sampling_rate" default:"1.0" envconfig:"SAMPLING_RATE"`
+	Enabled       bool                 `yaml:"enabled" json:"enabled" default:"false"`
+	Attributes    Map                  `yaml:"attributes" json:"attributes"`
+	Opentelemetry OpentelemetryTracing `yaml:"opentelemetry" json:"opentelemetry"`
+	SamplingRate  float64              `yaml:"sampling_rate" json:"sampling_rate" default:"1.0" envconfig:"SAMPLING_RATE"`
+}
+
+type OpentelemetryTracing struct {
+	Protocol OtlpProtocol `yaml:"protocol" json:"protocol" envconfig:"PROTOCOL" default:"http/protobuf"`
+	Endpoint string       `yaml:"endpoint" json:"endpoint" envconfig:"ENDPOINT" default:"http://localhost:4318/v1/traces"`
+}
+
+func (cfg OpentelemetryTracing) Validate() error {
+	if !slices.Contains([]OtlpProtocol{OtlpProtocolGRPC, OtlpProtocolHTTP}, cfg.Protocol) {
+		return fmt.Errorf("invalid protocol: %s", cfg.Protocol)
+	}
+	return nil
 }
 
 func (cfg TracingConfig) Validate() error {

--- a/pkg/metrics/opentelemetry.go
+++ b/pkg/metrics/opentelemetry.go
@@ -33,7 +33,7 @@ func newGRPCExporter(endpoint string) (metric.Exporter, error) {
 	return otlpmetricgrpc.New(context.Background(), opts...)
 }
 
-func SetupOpentelemetry(attributes map[string]string, cfg config.Opentelemetry, metrics *Metrics) error {
+func SetupOpentelemetry(attributes map[string]string, cfg config.OpentelemetryMetrics, metrics *Metrics) error {
 	var err error
 	var exporter metric.Exporter
 	switch cfg.Protocol {

--- a/pkg/tracing/opentelemetry.go
+++ b/pkg/tracing/opentelemetry.go
@@ -64,7 +64,7 @@ func SetupOTEL(o *config.TracingConfig) (trace.TracerProvider, error) {
 	return tracerProvider, err
 }
 
-func setupHTTPExporter(c config.Opentelemetry) (*otlptrace.Exporter, error) {
+func setupHTTPExporter(c config.OpentelemetryTracing) (*otlptrace.Exporter, error) {
 	endpoint, err := url.Parse(c.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid collector endpoint %q: %w", c.Endpoint, err)
@@ -86,7 +86,7 @@ func setupHTTPExporter(c config.Opentelemetry) (*otlptrace.Exporter, error) {
 	return otlptrace.New(context.Background(), otlptracehttp.NewClient(opts...))
 }
 
-func setupGRPCExporter(c config.Opentelemetry) (*otlptrace.Exporter, error) {
+func setupGRPCExporter(c config.OpentelemetryTracing) (*otlptrace.Exporter, error) {
 	host, port, err := net.SplitHostPort(c.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid collector endpoint %q: %w", c.Endpoint, err)


### PR DESCRIPTION
### Summary

- fixed default value of configuration `WEBHOOKX_TRACING_OPENTELEMETRY_ENDPOINT` to `http://localhost:4318/v1/traces`