### PR TITLE
refactor(dao): refactor dao

### DIFF
--- a/db/dao/attempt_dao.go
+++ b/db/dao/attempt_dao.go
@@ -85,7 +85,7 @@ func (dao *attemptDao) UpdateErrorCode(ctx context.Context, id string, status en
 
 func (dao *attemptDao) ListUnqueuedForUpdate(ctx context.Context, maxScheduledAt time.Time, limit int) (list []*entities.Attempt, err error) {
 	sql := "SELECT * FROM attempts WHERE status = 'INIT' AND created_at <= now() - INTERVAL '30 SECOND' AND scheduled_at < $1 limit $2 FOR UPDATE SKIP LOCKED"
-	err = dao.UnsafeDB(ctx).SelectContext(ctx, &list, sql, maxScheduledAt, limit)
+	err = dao.DB(ctx).SelectContext(ctx, &list, sql, maxScheduledAt, limit)
 	return
 }
 

--- a/db/dao/dao.go
+++ b/db/dao/dao.go
@@ -33,30 +33,27 @@ type Queryable interface {
 	SelectContext(context.Context, interface{}, string, ...interface{}) error
 }
 
-type DAO[T any] struct {
-	log *zap.SugaredLogger
-	db  *sqlx.DB
-
-	opts             Options
-	workspace        bool
-	insertionColumns []string
-	columns          map[string]bool
+type Schema interface {
+	PrimaryKey() string
 }
 
-func NewDAO[T any](db *sqlx.DB, opts Options) *DAO[T] {
+type DAO[T Schema] struct {
+	log    *zap.SugaredLogger
+	db     *sqlx.DB
+	schema *SchemaMeta
+
+	opts      Options
+	workspace bool
+}
+
+func NewDAO[T Schema](db *sqlx.DB, opts Options) *DAO[T] {
 	dao := DAO[T]{
 		log:       zap.S().Named("dao"),
 		db:        db,
 		opts:      opts,
 		workspace: opts.Workspace,
-		columns:   make(map[string]bool),
+		schema:    NewSchema[T](opts.EntityName),
 	}
-	EachField(new(T), func(f reflect.StructField, _ reflect.Value, column string) {
-		dao.columns[column] = true
-		if column != "created_at" && column != "updated_at" {
-			dao.insertionColumns = append(dao.insertionColumns, column)
-		}
-	})
 	return &dao
 }
 
@@ -83,16 +80,6 @@ func (dao *DAO[T]) DB(ctx context.Context) Queryable {
 	return dao.db
 }
 
-func (dao *DAO[T]) UnsafeDB(ctx context.Context) Queryable {
-	db := dao.DB(ctx)
-
-	if tx, ok := db.(*sqlx.Tx); ok {
-		return tx.Unsafe()
-	}
-
-	return db.(*sqlx.DB).Unsafe()
-}
-
 func (dao *DAO[T]) Get(ctx context.Context, id string) (entity *T, err error) {
 	ctx, span := dao.trace(ctx, fmt.Sprintf("dao.%s.get", dao.opts.Table))
 	defer span.End()
@@ -106,20 +93,7 @@ func (dao *DAO[T]) Select(ctx context.Context, field string, value string) (enti
 	statement, args := builder.MustSql()
 	dao.debugSQL(statement, args)
 	entity = new(T)
-	err = dao.UnsafeDB(ctx).GetContext(ctx, entity, statement, args...)
-	if errors.Is(err, ErrNoRows) {
-		return nil, nil
-	}
-	return
-}
-
-func (dao *DAO[T]) selectByField(ctx context.Context, field string, value string) (entity *T, err error) {
-	builder := psql.Select("*").From(dao.opts.Table).Where(sq.Eq{field: value})
-	builder = dao.workspaceFilter(ctx, builder)
-	statement, args := builder.MustSql()
-	dao.debugSQL(statement, args)
-	entity = new(T)
-	err = dao.UnsafeDB(ctx).GetContext(ctx, entity, statement, args...)
+	err = dao.DB(ctx).GetContext(ctx, entity, statement, args...)
 	if errors.Is(err, ErrNoRows) {
 		return nil, nil
 	}
@@ -135,25 +109,19 @@ func (dao *DAO[T]) Delete(ctx context.Context, id string) (bool, error) {
 		wid := contextx.GetWorkspaceID(ctx)
 		builder = builder.Where(sq.Eq{"ws_id": wid})
 	}
-	statement, args := builder.Suffix("RETURNING *").MustSql()
-	dao.debugSQL(statement, args)
-	entity := new(T)
-	err := dao.UnsafeDB(ctx).QueryRowxContext(ctx, statement, args...).StructScan(entity)
+	err := dao.executePropagate(ctx, builder, new(T))
 	if err != nil {
 		if errors.Is(err, ErrNoRows) {
 			return false, nil
 		}
 		return false, err
 	}
-	if dao.opts.CachePropagate {
-		go dao.propagateEvent(ctx, id, entity)
-	}
 	return true, nil
 }
 
-func appendWhere(allowedColumns map[string]bool, builder sq.SelectBuilder, conditions []Condition) sq.SelectBuilder {
+func appendWhere(schema *SchemaMeta, builder sq.SelectBuilder, conditions []Condition) sq.SelectBuilder {
 	for _, condition := range conditions {
-		if allowedColumns[condition.Column] {
+		if schema.HasColumn(condition.Column) {
 			switch condition.Op {
 			case Equal:
 				builder = builder.Where(sq.Eq{condition.Column: condition.Value})
@@ -197,7 +165,7 @@ func (dao *DAO[T]) Count(ctx context.Context, query *Query) (total int64, err er
 	defer span.End()
 
 	builder := psql.Select("COUNT(*)").From(dao.opts.Table)
-	builder = appendWhere(dao.columns, builder, query.Wheres)
+	builder = appendWhere(dao.schema, builder, query.Wheres)
 	builder = dao.workspaceFilter(ctx, builder)
 	statement, args := builder.MustSql()
 	dao.debugSQL(statement, args)
@@ -214,7 +182,7 @@ func (dao *DAO[T]) List(ctx context.Context, query *Query) (list []*T, err error
 	defer span.End()
 
 	builder := psql.Select("*").From(dao.opts.Table)
-	builder = appendWhere(dao.columns, builder, query.Wheres)
+	builder = appendWhere(dao.schema, builder, query.Wheres)
 	builder = dao.workspaceFilter(ctx, builder)
 	builder = appendOrder(builder, query.Orders)
 
@@ -228,7 +196,7 @@ func (dao *DAO[T]) List(ctx context.Context, query *Query) (list []*T, err error
 	statement, args := builder.MustSql()
 	dao.debugSQL(statement, args)
 	list = make([]*T, 0)
-	err = dao.UnsafeDB(ctx).SelectContext(ctx, &list, statement, args...)
+	err = dao.DB(ctx).SelectContext(ctx, &list, statement, args...)
 	return
 }
 
@@ -249,7 +217,7 @@ func (dao *DAO[T]) Cursor(ctx context.Context, query *Query) (cursor Cursor[*T],
 	defer span.End()
 
 	builder := psql.Select("*").From(dao.opts.Table)
-	builder = appendWhere(dao.columns, builder, query.Wheres)
+	builder = appendWhere(dao.schema, builder, query.Wheres)
 	builder = dao.workspaceFilter(ctx, builder)
 	builder = appendOrder(builder, query.Orders)
 	builder = builder.Limit(uint64(query.Limit + 1))
@@ -261,7 +229,7 @@ func (dao *DAO[T]) Cursor(ctx context.Context, query *Query) (cursor Cursor[*T],
 	dao.debugSQL(statement, args)
 
 	cursor.Data = make([]*T, 0)
-	err = dao.UnsafeDB(ctx).SelectContext(ctx, &cursor.Data, statement, args...)
+	err = dao.DB(ctx).SelectContext(ctx, &cursor.Data, statement, args...)
 	if err != nil {
 		return
 	}
@@ -317,18 +285,10 @@ func (dao *DAO[T]) Insert(ctx context.Context, entity *T) error {
 		}
 		values = append(values, value)
 	})
-	statement, args := psql.Insert(dao.opts.Table).Columns(dao.insertionColumns...).Values(values...).
-		Suffix("RETURNING *").
-		MustSql()
-	dao.debugSQL(statement, args)
-	err := dao.UnsafeDB(ctx).QueryRowxContext(ctx, statement, args...).StructScan(entity)
-	if dao.opts.CachePropagate && err == nil {
-		id := reflect.ValueOf(*entity).FieldByName("ID")
-		if id.IsValid() {
-			go dao.propagateEvent(ctx, id.String(), entity)
-		}
-	}
-	return errs.ConvertError(err)
+	builder := psql.Insert(dao.opts.Table).
+		Columns(dao.schema.InsertColumns()...).
+		Values(values...)
+	return dao.executePropagate(ctx, builder, entity)
 }
 
 func (dao *DAO[T]) BatchInsert(ctx context.Context, entities []*T) error {
@@ -339,7 +299,7 @@ func (dao *DAO[T]) BatchInsert(ctx context.Context, entities []*T) error {
 		return nil
 	}
 
-	builder := psql.Insert(dao.opts.Table).Columns(dao.insertionColumns...)
+	builder := psql.Insert(dao.opts.Table).Columns(dao.schema.InsertColumns()...)
 
 	for _, entity := range entities {
 		values := make([]interface{}, 0)
@@ -357,7 +317,7 @@ func (dao *DAO[T]) BatchInsert(ctx context.Context, entities []*T) error {
 	}
 
 	statement, args := builder.Suffix("RETURNING *").MustSql()
-	rows, err := dao.UnsafeDB(ctx).QueryxContext(ctx, statement, args...)
+	rows, err := dao.DB(ctx).QueryxContext(ctx, statement, args...)
 	if err != nil {
 		return err
 	}
@@ -372,32 +332,58 @@ func (dao *DAO[T]) BatchInsert(ctx context.Context, entities []*T) error {
 	return rows.Err()
 }
 
-func (dao *DAO[T]) update(ctx context.Context, id string, maps map[string]interface{}) (int64, error) {
+func (dao *DAO[T]) update(ctx context.Context, id string, maps map[string]interface{}) (entity *T, err error) {
 	builder := psql.Update(dao.opts.Table).SetMap(maps).Where(sq.Eq{"id": id})
 	if dao.workspace {
 		wid := contextx.GetWorkspaceID(ctx)
 		builder = builder.Where(sq.Eq{"ws_id": wid})
 	}
-	statement, args := builder.MustSql()
-	dao.debugSQL(statement, args)
-	result, err := dao.DB(ctx).ExecContext(ctx, statement, args...)
-	if err != nil {
-		return 0, err
+
+	entity = new(T)
+	err = dao.executePropagate(ctx, builder, entity)
+	return entity, err
+}
+
+func (dao *DAO[T]) executeReturning(ctx context.Context, builder interface{}, obj *T) error {
+	var statement string
+	var args []interface{}
+
+	switch t := builder.(type) {
+	case sq.UpdateBuilder:
+		statement, args = t.Suffix("RETURNING *").MustSql()
+	case sq.InsertBuilder:
+		statement, args = t.Suffix("RETURNING *").MustSql()
+	case sq.DeleteBuilder:
+		statement, args = t.Suffix("RETURNING *").MustSql()
+	default:
+		panic("invalid builder: " + reflect.TypeOf(t).String())
 	}
-	rows, err := result.RowsAffected()
-	return rows, err
+
+	dao.debugSQL(statement, args)
+
+	err := dao.DB(ctx).QueryRowxContext(ctx, statement, args...).StructScan(obj)
+	return errs.ConvertError(err)
+}
+
+func (dao *DAO[T]) executePropagate(ctx context.Context, builder interface{}, entity *T) error {
+	err := dao.executeReturning(ctx, builder, entity)
+	if err != nil {
+		return err
+	}
+
+	if dao.opts.CachePropagate {
+		go dao.propagateEvent(ctx, entity)
+	}
+	return nil
 }
 
 func (dao *DAO[T]) Update(ctx context.Context, entity *T) error {
 	ctx, span := dao.trace(ctx, fmt.Sprintf("dao.%s.update", dao.opts.Table))
 	defer span.End()
 
-	var id string
 	builder := psql.Update(dao.opts.Table)
 	EachField(entity, func(f reflect.StructField, v reflect.Value, column string) {
 		switch column {
-		case "id":
-			id = v.Interface().(string)
 		case "created_at": // ignore
 		case "updated_at":
 			builder = builder.Set(column, sq.Expr("NOW()"))
@@ -409,13 +395,9 @@ func (dao *DAO[T]) Update(ctx context.Context, entity *T) error {
 		wid := contextx.GetWorkspaceID(ctx)
 		builder = builder.Where(sq.Eq{"ws_id": wid})
 	}
-	statement, args := builder.Where(sq.Eq{"id": id}).Suffix("RETURNING *").MustSql()
-	dao.debugSQL(statement, args)
-	err := dao.UnsafeDB(ctx).QueryRowxContext(ctx, statement, args...).StructScan(entity)
-	if dao.opts.CachePropagate && err == nil {
-		go dao.propagateEvent(ctx, id, entity)
-	}
-	return errs.ConvertError(err)
+
+	builder = builder.Where(sq.Eq{"id": (*entity).PrimaryKey()})
+	return dao.executePropagate(ctx, builder, entity)
 }
 
 func (dao *DAO[T]) Upsert(ctx context.Context, fields []string, entity *T) error {
@@ -448,23 +430,17 @@ func (dao *DAO[T]) Upsert(ctx context.Context, fields []string, entity *T) error
 			clause.WriteString(", ")
 		}
 	}
-	statement, args := psql.Insert(dao.opts.Table).Columns(columns...).Values(values...).
-		Suffix("ON CONFLICT (" + strings.Join(fields, ",") + ") DO UPDATE SET " + clause.String()).
-		Suffix("RETURNING *").
-		MustSql()
-	dao.debugSQL(statement, args)
-	err := dao.UnsafeDB(ctx).QueryRowxContext(ctx, statement, args...).StructScan(entity)
-	if dao.opts.CachePropagate && err == nil {
-		id := reflect.ValueOf(*entity).FieldByName("ID")
-		if id.IsValid() {
-			go dao.propagateEvent(ctx, id.String(), entity)
-		}
-	}
-	return errs.ConvertError(err)
+
+	bulder := psql.Insert(dao.opts.Table).
+		Columns(columns...).
+		Values(values...).
+		Suffix("ON CONFLICT (" + strings.Join(fields, ",") + ") DO UPDATE SET " + clause.String())
+
+	return dao.executePropagate(ctx, bulder, entity)
 }
 
-func (dao *DAO[T]) propagateEvent(ctx context.Context, id string, entity *T) {
+func (dao *DAO[T]) propagateEvent(ctx context.Context, entity *T) {
 	ctx, span := dao.trace(ctx, fmt.Sprintf("%s.crud.broadcast", dao.opts.Table))
 	defer span.End()
-	dao.opts.PropagateHandler(ctx, &dao.opts, id, entity)
+	dao.opts.PropagateHandler(ctx, &dao.opts, (*entity).PrimaryKey(), entity)
 }

--- a/db/dao/dao_test.go
+++ b/db/dao/dao_test.go
@@ -2,32 +2,76 @@ package dao
 
 import (
 	"context"
-	"maps"
-	"slices"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
-	"github.com/webhookx-io/webhookx/db/entities"
 )
 
-type TestEntity struct {
-	ID   string  `json:"id" db:"id"`
-	Name *string `json:"name" db:"name"`
-	entities.BaseModel
+func newSqliteDB() *sqlx.DB {
+	db := sqlx.MustOpen("sqlite3", ":memory:")
+	schema := `
+    CREATE TABLE test (
+        id varchar(27) PRIMARY KEY,
+        name TEXT,
+        unknown TEXT,
+        ws_id varchar(27)
+    );`
+	db.MustExec(schema)
+	db.MustExec(
+		"INSERT INTO test (id, name, ws_id) VALUES (?, ?, ?)",
+		"00000000-0000-0000-0000-000000000000",
+		"test",
+		"")
+	return db.Unsafe()
 }
 
-func TestNewDAO(t *testing.T) {
-	dao := NewDAO[TestEntity](nil, Options{
-		Table: "test_table",
+var _ = Describe("dao", Ordered, func() {
+
+	var dao *DAO[TestEntity]
+	BeforeAll(func() {
+		db := newSqliteDB()
+		dao = NewDAO[TestEntity](db, Options{Table: "test"})
 	})
 
-	assert.Equal(t, "test_table", dao.opts.Table)
-	assert.Equal(t, []string{"id", "name", "ws_id"}, dao.insertionColumns)
+	Context("Delete", func() {
+		It("return true, nil", func() {
+			dao.db.MustExec(
+				"INSERT INTO test (id, name, ws_id) VALUES (?, ?, ?)",
+				"to-be-deleted",
+				"test",
+				"")
+			ok, err := dao.Delete(context.TODO(), "to-be-deleted")
+			assert.Nil(GinkgoT(), err)
+			assert.Equal(GinkgoT(), true, ok)
+		})
 
-	assert.Equal(t, 5, len(dao.columns))
-	columns := slices.Collect(maps.Keys(dao.columns))
-	slices.Sort(columns)
-	assert.EqualValues(t, []string{"created_at", "id", "name", "updated_at", "ws_id"}, columns)
+		It("returns false, nil", func() {
+			ok, err := dao.Delete(context.TODO(), "")
+			assert.Nil(GinkgoT(), err)
+			assert.Equal(GinkgoT(), false, ok)
+		})
+	})
+
+	Context("errors", func() {
+		It("returns no err when table has unknown columns", func() {
+			entity, err := dao.Get(context.TODO(), "00000000-0000-0000-0000-000000000000")
+			assert.NoError(GinkgoT(), err)
+			assert.Nil(GinkgoT(), err)
+			assert.NotNil(GinkgoT(), entity)
+			assert.Equal(GinkgoT(), "test", *entity.Name)
+			assert.Equal(GinkgoT(), "00000000-0000-0000-0000-000000000000", entity.ID)
+		})
+	})
+
+})
+
+func TestDAO(t *testing.T) {
+	gomega.RegisterFailHandler(Fail)
+	RunSpecs(t, "DAO")
 }
 
 func TestList(t *testing.T) {

--- a/db/dao/event_dao.go
+++ b/db/dao/event_dao.go
@@ -37,7 +37,7 @@ func (dao *eventDao) ListExistingUniqueIDs(ctx context.Context, uniques []string
 		Where(sq.Eq{"unique_id": uniques}).
 		MustSql()
 	dao.debugSQL(statement, args)
-	err = dao.UnsafeDB(ctx).SelectContext(ctx, &list, statement, args...)
+	err = dao.DB(ctx).SelectContext(ctx, &list, statement, args...)
 	return
 }
 

--- a/db/dao/schema_meta.go
+++ b/db/dao/schema_meta.go
@@ -1,0 +1,44 @@
+package dao
+
+import (
+	"maps"
+	"reflect"
+	"slices"
+)
+
+
+type SchemaMeta struct {
+	Name          string
+	insertColumns []string
+	columns       map[string]bool
+}
+
+func NewSchema[T any](name string) *SchemaMeta {
+	schema := &SchemaMeta{
+		Name:    name,
+		columns: make(map[string]bool),
+	}
+
+	EachField(new(T), func(f reflect.StructField, _ reflect.Value, column string) {
+		schema.columns[column] = true
+		if column != "created_at" && column != "updated_at" {
+			schema.insertColumns = append(schema.insertColumns, column)
+		}
+	})
+
+	return schema
+}
+
+func (s *SchemaMeta) HasColumn(column string) bool {
+	return s.columns[column]
+}
+
+func (s *SchemaMeta) InsertColumns() []string {
+	return s.insertColumns
+}
+
+func (s *SchemaMeta) Columns() []string {
+	columns := slices.Collect(maps.Keys(s.columns))
+	slices.Sort(columns)
+	return columns
+}

--- a/db/dao/schema_meta_test.go
+++ b/db/dao/schema_meta_test.go
@@ -1,0 +1,28 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/webhookx-io/webhookx/db/entities"
+)
+
+type TestEntity struct {
+	ID     string  `json:"id" db:"id"`
+	Name   *string `json:"name" db:"name"`
+	Ignore string  `json:"ignore" db:"-"`
+	entities.BaseModel
+}
+
+func (m TestEntity) PrimaryKey() string {
+	return m.ID
+}
+
+func TestSchemaMeta(t *testing.T) {
+	schema := NewSchema[TestEntity]("test_schema")
+
+	assert.Equal(t, "test_schema", schema.Name)
+	assert.EqualValues(t, []string{"id", "name", "ws_id"}, schema.InsertColumns())
+	assert.EqualValues(t, []string{"created_at", "id", "name", "updated_at", "ws_id"}, schema.Columns())
+	assert.Equal(t, false, schema.HasColumn("foo"))
+}

--- a/db/dao/workspace_dao.go
+++ b/db/dao/workspace_dao.go
@@ -28,11 +28,11 @@ func NewWorkspaceDAO(db *sqlx.DB, fns ...OptionFunc) WorkspaceDAO {
 }
 
 func (dao *workspaceDAO) GetDefault(ctx context.Context) (*entities.Workspace, error) {
-	return dao.selectByField(ctx, "name", "default")
+	return dao.Select(ctx, "name", "default")
 }
 
 func (dao *workspaceDAO) GetWorkspace(ctx context.Context, name string) (*entities.Workspace, error) {
-	return dao.selectByField(ctx, "name", name)
+	return dao.Select(ctx, "name", name)
 }
 
 type WorkspaceQuery struct {

--- a/db/db.go
+++ b/db/db.go
@@ -51,7 +51,7 @@ func NewSqlDB(cfg modules.DatabaseConfig) (*sql.DB, error) {
 }
 
 func NewDB(sqlDB *sql.DB, log *zap.SugaredLogger, bus eventbus.EventBus) (*DB, error) {
-	sqlxDB := sqlx.NewDb(sqlDB, "pgx")
+	sqlxDB := sqlx.NewDb(sqlDB, "pgx").Unsafe()
 
 	opts := make([]dao.OptionFunc, 0)
 	opts = append(opts, dao.WithPropagateHandler(func(ctx context.Context, opts *dao.Options, id string, entity interface{}) {

--- a/db/entities/attempt.go
+++ b/db/entities/attempt.go
@@ -27,6 +27,10 @@ type Attempt struct {
 	BaseModel
 }
 
+func (m Attempt) PrimaryKey() string {
+	return m.ID
+}
+
 type AttemptStatus = string
 
 const (

--- a/db/entities/attempt_detail.go
+++ b/db/entities/attempt_detail.go
@@ -9,3 +9,8 @@ type AttemptDetail struct {
 
 	BaseModel
 }
+
+func (m AttemptDetail) PrimaryKey() string {
+	return m.ID
+}
+

--- a/db/entities/endpoint.go
+++ b/db/entities/endpoint.go
@@ -21,6 +21,10 @@ type Endpoint struct {
 	BaseModel
 }
 
+func (m Endpoint) PrimaryKey() string {
+	return m.ID
+}
+
 func (m *Endpoint) SchemaName() string {
 	return "Endpoint"
 }

--- a/db/entities/event.go
+++ b/db/entities/event.go
@@ -17,6 +17,10 @@ type Event struct {
 	BaseModel
 }
 
+func (m Event) PrimaryKey() string {
+	return m.ID
+}
+
 func (m *Event) SchemaName() string {
 	return "Event"
 }

--- a/db/entities/plugin.go
+++ b/db/entities/plugin.go
@@ -23,6 +23,10 @@ type Plugin struct {
 	BaseModel
 }
 
+func (m Plugin) PrimaryKey() string {
+	return m.ID
+}
+
 func (m *Plugin) SchemaName() string {
 	return "Plugin"
 }

--- a/db/entities/source.go
+++ b/db/entities/source.go
@@ -52,6 +52,10 @@ type Source struct {
 	BaseModel
 }
 
+func (m Source) PrimaryKey() string {
+	return m.ID
+}
+
 func (m *Source) SchemaName() string {
 	return "Source"
 }

--- a/db/entities/workspace.go
+++ b/db/entities/workspace.go
@@ -14,6 +14,10 @@ type Workspace struct {
 	UpdatedAt types.Time `db:"updated_at" json:"updated_at"`
 }
 
+func (m Workspace) PrimaryKey() string {
+	return m.ID
+}
+
 func (m *Workspace) SchemaName() string {
 	return "Workspace"
 }

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.11.1
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1


### PR DESCRIPTION
### Summary

- Entities now implement the interface `Schema`, eliminating the need to retrieve primary keys via reflection.
- SchemaMeta to store/collecting schema's metadata。