### PR TITLE
refactor(entities): use TypeID

### DIFF
--- a/admin/api/endpoints.go
+++ b/admin/api/endpoints.go
@@ -7,6 +7,7 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/contextx"
 	"github.com/webhookx-io/webhookx/pkg/openapi"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
@@ -45,7 +46,7 @@ func (api *API) GetEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) CreateEndpoint(w http.ResponseWriter, r *http.Request) {
 	var endpoint entities.Endpoint
-	defaults := map[string]interface{}{"id": utils.KSUID()}
+	defaults := map[string]interface{}{"id": uid.Generate(uid.EndpointPrefix)}
 	if err := ValidateRequest(r, defaults, &endpoint); err != nil {
 		api.error(400, w, err)
 		return

--- a/admin/api/events.go
+++ b/admin/api/events.go
@@ -9,8 +9,8 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/contextx"
 	"github.com/webhookx-io/webhookx/pkg/openapi"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/services/eventbus"
-	"github.com/webhookx-io/webhookx/utils"
 )
 
 func (api *API) PageEvent(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func (api *API) GetEvent(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) CreateEvent(w http.ResponseWriter, r *http.Request) {
 	var event entities.Event
-	defaults := map[string]interface{}{"id": utils.KSUID()}
+	defaults := map[string]interface{}{"id": uid.Generate(uid.EventPrefix)}
 	if err := ValidateRequest(r, defaults, &event); err != nil {
 		api.error(400, w, err)
 		return

--- a/admin/api/plugins.go
+++ b/admin/api/plugins.go
@@ -8,6 +8,7 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/errs"
 	"github.com/webhookx-io/webhookx/pkg/openapi"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
@@ -46,7 +47,7 @@ func (api *API) GetPlugin(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) CreatePlugin(w http.ResponseWriter, r *http.Request) {
 	var model entities.Plugin
-	defaults := map[string]interface{}{"id": utils.KSUID()}
+	defaults := map[string]interface{}{"id": uid.Generate(uid.PluginPrefix)}
 	if err := ValidateRequest(r, defaults, &model); err != nil {
 		api.error(400, w, err)
 		return

--- a/admin/api/sources.go
+++ b/admin/api/sources.go
@@ -7,6 +7,7 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/contextx"
 	"github.com/webhookx-io/webhookx/pkg/openapi"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
@@ -45,7 +46,7 @@ func (api *API) GetSource(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) CreateSource(w http.ResponseWriter, r *http.Request) {
 	var source entities.Source
-	defaults := map[string]interface{}{"id": utils.KSUID()}
+	defaults := map[string]interface{}{"id": uid.Generate(uid.SourcePrefix)}
 	if err := ValidateRequest(r, defaults, &source); err != nil {
 		api.error(400, w, err)
 		return

--- a/admin/api/workspaces.go
+++ b/admin/api/workspaces.go
@@ -7,6 +7,7 @@ import (
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/openapi"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
@@ -45,13 +46,13 @@ func (api *API) GetWorkspace(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	var workspace entities.Workspace
-	defaults := map[string]interface{}{"id": utils.KSUID()}
+	defaults := map[string]interface{}{"id": uid.Generate(uid.WorkspacePrefix)}
 	if err := ValidateRequest(r, defaults, &workspace); err != nil {
 		api.error(400, w, err)
 		return
 	}
 
-	workspace.ID = utils.KSUID()
+	workspace.ID = uid.Generate(uid.WorkspacePrefix)
 	err := api.db.Workspaces.Insert(r.Context(), &workspace)
 	api.assert(err)
 

--- a/db/migrations/1778517090_typeid.down.sql
+++ b/db/migrations/1778517090_typeid.down.sql
@@ -1,0 +1,29 @@
+ALTER TABLE "attempt_details"
+ALTER COLUMN "id" TYPE CHAR(27),
+    ALTER COLUMN "ws_id" TYPE CHAR(27);
+
+ALTER TABLE "attempts"
+ALTER COLUMN "id" TYPE CHAR(27),
+    ALTER COLUMN "event_id" TYPE CHAR(27),
+    ALTER COLUMN "endpoint_id" TYPE CHAR(27),
+    ALTER COLUMN "ws_id" TYPE CHAR(27);
+
+ALTER TABLE "endpoints"
+ALTER COLUMN "id" TYPE CHAR(27),
+    ALTER COLUMN "ws_id" TYPE CHAR(27);
+
+ALTER TABLE "events"
+ALTER COLUMN "id" TYPE CHAR(27),
+    ALTER COLUMN "ws_id" TYPE CHAR(27);
+
+ALTER TABLE "plugins"
+ALTER COLUMN "id" TYPE CHAR(27),
+    ALTER COLUMN "source_id" TYPE CHAR(27),
+    ALTER COLUMN "endpoint_id" TYPE CHAR(27),
+    ALTER COLUMN "ws_id" TYPE CHAR(27);
+
+ALTER TABLE "sources"
+ALTER COLUMN "id" TYPE CHAR(27),
+    ALTER COLUMN "ws_id" TYPE CHAR(27);
+
+ALTER TABLE "workspaces" ALTER COLUMN "id" TYPE CHAR(27);

--- a/db/migrations/1778517090_typeid.up.sql
+++ b/db/migrations/1778517090_typeid.up.sql
@@ -1,0 +1,29 @@
+ALTER TABLE "attempt_details"
+    ALTER COLUMN "id" TYPE TEXT,
+    ALTER COLUMN "ws_id" TYPE TEXT;
+
+ALTER TABLE "attempts"
+    ALTER COLUMN "id" TYPE TEXT,
+    ALTER COLUMN "event_id" TYPE TEXT,
+    ALTER COLUMN "endpoint_id" TYPE TEXT,
+    ALTER COLUMN "ws_id" TYPE TEXT;
+
+ALTER TABLE "endpoints"
+    ALTER COLUMN "id" TYPE TEXT,
+    ALTER COLUMN "ws_id" TYPE TEXT;
+
+ALTER TABLE "events"
+    ALTER COLUMN "id" TYPE TEXT,
+    ALTER COLUMN "ws_id" TYPE TEXT;
+
+ALTER TABLE "plugins"
+    ALTER COLUMN "id" TYPE TEXT,
+    ALTER COLUMN "source_id" TYPE TEXT,
+    ALTER COLUMN "endpoint_id" TYPE TEXT,
+    ALTER COLUMN "ws_id" TYPE TEXT;
+
+ALTER TABLE "sources"
+    ALTER COLUMN "id" TYPE TEXT,
+    ALTER COLUMN "ws_id" TYPE TEXT;
+
+ALTER TABLE "workspaces" ALTER COLUMN "id" TYPE TEXT;

--- a/db/migrator/migrator.go
+++ b/db/migrator/migrator.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/webhookx-io/webhookx/db/migrations"
-	"github.com/webhookx-io/webhookx/utils"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 )
 
 type Log struct{}
@@ -185,6 +185,6 @@ func (m *Migrator) Status() (status Status, err error) {
 
 func (m *Migrator) initDefaultWorkspace() error {
 	sql := `INSERT INTO workspaces(id, name) VALUES($1, 'default') ON CONFLICT(name) DO NOTHING;`
-	_, err := m.db.Exec(sql, utils.KSUID())
+	_, err := m.db.Exec(sql, uid.Generate(uid.WorkspacePrefix))
 	return err
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -10,8 +10,8 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/metrics"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/services/eventbus"
-	"github.com/webhookx-io/webhookx/utils"
 	"go.uber.org/zap"
 )
 
@@ -122,7 +122,7 @@ func fanout(event *entities.Event, endpoints []*entities.Endpoint, mode entities
 	for _, endpoint := range endpoints {
 		delay := endpoint.Retry.Config.Attempts[0]
 		attempt := &entities.Attempt{
-			ID:            utils.KSUID(),
+			ID:            uid.Generate(uid.AttemptPrefix),
 			EventId:       event.ID,
 			EndpointId:    endpoint.ID,
 			Status:        entities.AttemptStatusInit,

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/satori/go.uuid v1.2.0
-	github.com/segmentio/ksuid v1.0.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v84 v84.4.1
@@ -49,6 +48,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/webhookx-io/webhookx/api/license v0.1.0
+	go.jetify.com/typeid/v2 v2.0.0-alpha.3
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/autoprop v0.68.0
 	go.opentelemetry.io/otel v1.43.0
@@ -133,6 +133,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/gofrs/uuid/v5 v5.3.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/gofrs/uuid/v5 v5.3.2 h1:2jfO8j3XgSwlz/wHqemAEugfnTlikAYHhnqQ8Xh4fE0=
+github.com/gofrs/uuid/v5 v5.3.2/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-migrate/migrate/v4 v4.19.1 h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7gH9yH4jSFbBA=
@@ -285,8 +287,6 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEV
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
-github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -324,6 +324,8 @@ github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIj
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
+go.jetify.com/typeid/v2 v2.0.0-alpha.3 h1:T6RPx6bNl10lp0JN2Xz/XcgLZWSlVmL58Xqy9cgTCcc=
+go.jetify.com/typeid/v2 v2.0.0-alpha.3/go.mod h1:zfD1ZDHDJNgXZANsO9jDOD81XRRQ0zAOnDBEHmIV/Gw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 h1:CqXxU8VOmDefoh0+ztfGaymYbhdB/tT3zs79QaZTNGY=

--- a/pkg/declarative/types.go
+++ b/pkg/declarative/types.go
@@ -2,6 +2,7 @@ package declarative
 
 import (
 	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
@@ -19,22 +20,22 @@ func (cfg *Configuration) SchemaName() string {
 func (cfg *Configuration) Init() {
 	for _, m := range cfg.Sources {
 		if m.ID == "" {
-			m.ID = utils.KSUID()
+			m.ID = uid.Generate(uid.SourcePrefix)
 		}
 		for _, p := range m.Plugins {
 			if p.ID == "" {
-				p.ID = utils.KSUID()
+				p.ID = uid.Generate(uid.PluginPrefix)
 			}
 			p.SourceId = new(m.ID)
 		}
 	}
 	for _, m := range cfg.Endpoints {
 		if m.ID == "" {
-			m.ID = utils.KSUID()
+			m.ID = uid.Generate(uid.EndpointPrefix)
 		}
 		for _, p := range m.Plugins {
 			if p.ID == "" {
-				p.ID = utils.KSUID()
+				p.ID = uid.Generate(uid.PluginPrefix)
 			}
 			p.EndpointId = new(m.ID)
 		}

--- a/pkg/uid/uid.go
+++ b/pkg/uid/uid.go
@@ -1,0 +1,29 @@
+package uid
+
+import (
+	"go.jetify.com/typeid/v2"
+)
+
+type Prefix string
+
+func (p Prefix) String() string {
+	return string(p)
+}
+
+const (
+	AttemptPrefix   Prefix = "at"
+	EndpointPrefix  Prefix = "end"
+	EventPrefix     Prefix = "evt"
+	PluginPrefix    Prefix = "plg"
+	SourcePrefix    Prefix = "src"
+	WorkspacePrefix Prefix = "ws"
+)
+
+func Generate(prefix Prefix) string {
+	return genTypeID(prefix.String())
+}
+
+
+func genTypeID(prefix string) string {
+	return typeid.MustGenerate(prefix).String()
+}

--- a/pkg/uid/uid_test.go
+++ b/pkg/uid/uid_test.go
@@ -1,0 +1,35 @@
+package uid
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test(t *testing.T) {
+	t.Run("attempt prefix", func(t *testing.T) {
+		id := Generate(AttemptPrefix)
+		assert.True(t, strings.HasPrefix(id, "at_"))
+	})
+	t.Run("endpoint prefix", func(t *testing.T) {
+		id := Generate(EndpointPrefix)
+		assert.True(t, strings.HasPrefix(id, "end_"))
+	})
+	t.Run("event prefix", func(t *testing.T) {
+		id := Generate(EventPrefix)
+		assert.True(t, strings.HasPrefix(id, "evt_"))
+	})
+	t.Run("plugin prefix", func(t *testing.T) {
+		id := Generate(PluginPrefix)
+		assert.True(t, strings.HasPrefix(id, "plg_"))
+	})
+	t.Run("source prefix", func(t *testing.T) {
+		id := Generate(SourcePrefix)
+		assert.True(t, strings.HasPrefix(id, "src_"))
+	})
+	t.Run("workspace prefix", func(t *testing.T) {
+		id := Generate(WorkspacePrefix)
+		assert.True(t, strings.HasPrefix(id, "ws_"))
+	})
+}

--- a/proxy/gateway.go
+++ b/proxy/gateway.go
@@ -33,6 +33,7 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/store"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/plugins"
 	"github.com/webhookx-io/webhookx/proxy/router"
 	"github.com/webhookx-io/webhookx/services"
@@ -279,7 +280,7 @@ func (g *Gateway) handleRequest(w http.ResponseWriter, r *http.Request) (*Respon
 		}
 	}
 
-	event.ID = utils.KSUID()
+	event.ID = uid.Generate(uid.EventPrefix)
 	event.IngestedAt = types.Time{Time: time.Now()}
 	event.WorkspaceId = source.WorkspaceId
 	if err := event.Validate(); err != nil {

--- a/test/admin/attempts_test.go
+++ b/test/admin/attempts_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/test/helper"
 	"github.com/webhookx-io/webhookx/utils"
 )
@@ -44,7 +45,7 @@ var _ = Describe("/attempts", Ordered, func() {
 			BeforeAll(func() {
 				assert.NoError(GinkgoT(), db.Truncate("attempts"))
 				endpoint1 := entities.Endpoint{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.EndpointPrefix),
 					Enabled: true,
 					Request: entities.RequestConfig{
 						URL:    "https://example.com",
@@ -56,7 +57,7 @@ var _ = Describe("/attempts", Ordered, func() {
 				endpoints = append(endpoints, &endpoint1)
 
 				endpoint2 := entities.Endpoint{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.EndpointPrefix),
 					Enabled: true,
 					Request: entities.RequestConfig{
 						URL:    "https://example.com",
@@ -69,7 +70,7 @@ var _ = Describe("/attempts", Ordered, func() {
 
 				for i := 1; i <= 21; i++ {
 					event := &entities.Event{
-						ID:        utils.KSUID(),
+						ID:        uid.Generate(uid.EventPrefix),
 						EventType: "foo.bar",
 						Data:      []byte("{}"),
 					}
@@ -77,7 +78,7 @@ var _ = Describe("/attempts", Ordered, func() {
 					assert.NoError(GinkgoT(), db.Events.Insert(context.TODO(), event))
 					events = append(events, event)
 					attempt := entities.Attempt{
-						ID:            utils.KSUID(),
+						ID:            uid.Generate(uid.AttemptPrefix),
 						EventId:       event.ID,
 						EndpointId:    endpoints[i%2].ID,
 						Status:        entities.AttemptStatusSuccess,
@@ -153,7 +154,7 @@ var _ = Describe("/attempts", Ordered, func() {
 				entitiesConfig := helper.TestEntities{
 					Endpoints: []*entities.Endpoint{
 						{
-							ID:      utils.KSUID(),
+							ID:      uid.Generate(uid.EndpointPrefix),
 							Enabled: true,
 							Request: entities.RequestConfig{
 								URL:    "https://example.com",
@@ -163,14 +164,14 @@ var _ = Describe("/attempts", Ordered, func() {
 					},
 					Events: []*entities.Event{
 						{
-							ID:        utils.KSUID(),
+							ID:        uid.Generate(uid.EventPrefix),
 							EventType: "foo.bar",
 							Data:      []byte("{}"),
 						},
 					},
 				}
 				entity = &entities.Attempt{
-					ID:            utils.KSUID(),
+					ID:            uid.Generate(uid.AttemptPrefix),
 					EventId:       entitiesConfig.Events[0].ID,
 					EndpointId:    entitiesConfig.Endpoints[0].ID,
 					Status:        entities.AttemptStatusSuccess,
@@ -188,7 +189,7 @@ var _ = Describe("/attempts", Ordered, func() {
 					Exhausted:   false,
 				}
 				undeliveredAttempt = &entities.Attempt{
-					ID:            utils.KSUID(),
+					ID:            uid.Generate(uid.AttemptPrefix),
 					EventId:       entitiesConfig.Events[0].ID,
 					EndpointId:    entitiesConfig.Endpoints[0].ID,
 					Status:        entities.AttemptStatusQueued,

--- a/test/admin/endpoints_test.go
+++ b/test/admin/endpoints_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/test/helper"
-	"github.com/webhookx-io/webhookx/utils"
 )
 
 var _ = Describe("/endpoints", Ordered, func() {
@@ -546,7 +546,7 @@ var _ = Describe("/endpoints", Ordered, func() {
 			var entity *entities.Endpoint
 			BeforeAll(func() {
 				entity = &entities.Endpoint{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.EndpointPrefix),
 					Enabled: true,
 					Request: entities.RequestConfig{
 						URL:    "https://example.com",
@@ -584,7 +584,7 @@ var _ = Describe("/endpoints", Ordered, func() {
 			var entity *entities.Endpoint
 			BeforeAll(func() {
 				entity = &entities.Endpoint{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.EndpointPrefix),
 					Enabled: true,
 					Request: entities.RequestConfig{
 						URL:    "https://example.com",
@@ -627,7 +627,7 @@ var _ = Describe("/endpoints", Ordered, func() {
 			var entity *entities.Endpoint
 			BeforeAll(func() {
 				entity = &entities.Endpoint{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.EndpointPrefix),
 					Enabled: true,
 					Request: entities.RequestConfig{
 						URL:    "https://example.com",

--- a/test/admin/events_test.go
+++ b/test/admin/events_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/webhookx-io/webhookx/db/dao"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/test/helper"
 	"github.com/webhookx-io/webhookx/test/helper/factory"
 	"github.com/webhookx-io/webhookx/utils"
@@ -45,7 +46,7 @@ var _ = Describe("/events", Ordered, func() {
 				assert.NoError(GinkgoT(), db.Truncate("events"))
 				for i := 1; i <= 21; i++ {
 					event := &entities.Event{
-						ID:         utils.KSUID(),
+						ID:         uid.Generate(uid.EventPrefix),
 						EventType:  "foo.bar",
 						Data:       []byte("{}"),
 						IngestedAt: types.Time{Time: time.Now()},
@@ -130,7 +131,7 @@ var _ = Describe("/events", Ordered, func() {
 				entitiesConfig := helper.TestEntities{
 					Events: []*entities.Event{
 						{
-							ID:         utils.KSUID(),
+							ID:         uid.Generate(uid.EventPrefix),
 							EventType:  "foo.bar",
 							Data:       []byte("{}"),
 							IngestedAt: types.Time{Time: time.Now()},

--- a/test/admin/plugins_test.go
+++ b/test/admin/plugins_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/plugin"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	key_auth "github.com/webhookx-io/webhookx/plugins/key-auth"
 	"github.com/webhookx-io/webhookx/test/fixtures/plugins/hello"
 	"github.com/webhookx-io/webhookx/test/fixtures/plugins/inbound"
@@ -58,7 +59,7 @@ var _ = Describe("/plugins", Ordered, func() {
 					endpoint := factory.EndpointWS(ws.ID)
 					assert.NoError(GinkgoT(), db.Endpoints.Insert(context.TODO(), endpoint))
 					plugin := entities.Plugin{
-						ID:         utils.KSUID(),
+						ID:         uid.Generate(uid.PluginPrefix),
 						EndpointId: new(endpoint.ID),
 						Name:       "webhookx-signature",
 						Enabled:    true,
@@ -521,7 +522,7 @@ var _ = Describe("/plugins", Ordered, func() {
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 				assert.Equal(GinkgoT(),
-					`{"message":"foreign key violation: {source_id='foo                        '} does not reference an existing record in 'sources'"}`,
+					`{"message":"foreign key violation: {source_id='foo'} does not reference an existing record in 'sources'"}`,
 					string(resp.Body()))
 			})
 
@@ -538,7 +539,7 @@ var _ = Describe("/plugins", Ordered, func() {
 				assert.Nil(GinkgoT(), err)
 				assert.Equal(GinkgoT(), 400, resp.StatusCode())
 				assert.Equal(GinkgoT(),
-					`{"message":"foreign key violation: {endpoint_id='foo                        '} does not reference an existing record in 'endpoints'"}`,
+					`{"message":"foreign key violation: {endpoint_id='foo'} does not reference an existing record in 'endpoints'"}`,
 					string(resp.Body()))
 			})
 
@@ -553,7 +554,7 @@ var _ = Describe("/plugins", Ordered, func() {
 					Endpoints: []*entities.Endpoint{factory.Endpoint()},
 				}
 				entity = &entities.Plugin{
-					ID:         utils.KSUID(),
+					ID:         uid.Generate(uid.PluginPrefix),
 					EndpointId: new(entitiesConfig.Endpoints[0].ID),
 					Name:       "webhookx-signature",
 					Enabled:    true,
@@ -594,7 +595,7 @@ var _ = Describe("/plugins", Ordered, func() {
 
 			BeforeAll(func() {
 				endpoint = &entities.Endpoint{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.EndpointPrefix),
 					Enabled: true,
 					Request: entities.RequestConfig{
 						URL:    "https://example.com",
@@ -605,7 +606,7 @@ var _ = Describe("/plugins", Ordered, func() {
 				assert.Nil(GinkgoT(), db.Endpoints.Insert(context.TODO(), endpoint))
 
 				plugin = &entities.Plugin{
-					ID:         utils.KSUID(),
+					ID:         uid.Generate(uid.PluginPrefix),
 					Name:       "webhookx-signature",
 					Enabled:    true,
 					EndpointId: new(endpoint.ID),
@@ -677,7 +678,7 @@ var _ = Describe("/plugins", Ordered, func() {
 			var entity *entities.Plugin
 			BeforeAll(func() {
 				endpoint := &entities.Endpoint{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.EndpointPrefix),
 					Enabled: true,
 					Request: entities.RequestConfig{
 						URL:    "https://example.com",
@@ -688,7 +689,7 @@ var _ = Describe("/plugins", Ordered, func() {
 				assert.Nil(GinkgoT(), db.Endpoints.Insert(context.TODO(), endpoint))
 
 				entity = &entities.Plugin{
-					ID:         utils.KSUID(),
+					ID:         uid.Generate(uid.PluginPrefix),
 					Name:       "webhookx-signature",
 					Enabled:    true,
 					EndpointId: new(endpoint.ID),

--- a/test/admin/sources_test.go
+++ b/test/admin/sources_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/test/helper"
 	"github.com/webhookx-io/webhookx/test/helper/factory"
-	"github.com/webhookx-io/webhookx/utils"
 )
 
 var _ = Describe("/sources", Ordered, func() {
@@ -301,7 +301,7 @@ var _ = Describe("/sources", Ordered, func() {
 			var entity *entities.Source
 			BeforeAll(func() {
 				entity = &entities.Source{
-					ID:      utils.KSUID(),
+					ID:      uid.Generate(uid.SourcePrefix),
 					Enabled: true,
 				}
 				entity.WorkspaceId = ws.ID

--- a/test/admin/workspaces_test.go
+++ b/test/admin/workspaces_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/webhookx-io/webhookx/app"
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/test/helper"
-	"github.com/webhookx-io/webhookx/utils"
 )
 
 var _ = Describe("/workspaces", Ordered, func() {
@@ -120,7 +120,7 @@ var _ = Describe("/workspaces", Ordered, func() {
 			var entity *entities.Workspace
 			BeforeAll(func() {
 				entity = &entities.Workspace{
-					ID:   utils.KSUID(),
+					ID:   uid.Generate(uid.WorkspacePrefix),
 					Name: new("test-update-workspace"),
 				}
 				assert.Nil(GinkgoT(), db.Workspaces.Insert(context.TODO(), entity))
@@ -160,7 +160,7 @@ var _ = Describe("/workspaces", Ordered, func() {
 			var entity *entities.Workspace
 			BeforeAll(func() {
 				entity = &entities.Workspace{
-					ID: utils.KSUID(),
+					ID: uid.Generate(uid.WorkspacePrefix),
 				}
 				assert.Nil(GinkgoT(), db.Workspaces.Insert(context.TODO(), entity))
 			})

--- a/test/cmd/db_test.go
+++ b/test/cmd/db_test.go
@@ -21,11 +21,12 @@ var statusOutputInit = `1 init (⏳ pending)
 10 ratelimit (⏳ pending)
 11 event_unique_id (⏳ pending)
 1762423418 source_config (⏳ pending)
+1778517090 typeid (⏳ pending)
 Summary:
   Current version: 0
   Dirty: false
   Executed: 0
-  Pending: 12
+  Pending: 13
 `
 
 var statusOutputDone = `1 init (✅ executed)
@@ -40,10 +41,11 @@ var statusOutputDone = `1 init (✅ executed)
 10 ratelimit (✅ executed)
 11 event_unique_id (✅ executed)
 1762423418 source_config (✅ executed)
+1778517090 typeid (✅ executed)
 Summary:
-  Current version: 1762423418
+  Current version: 1778517090
   Dirty: false
-  Executed: 12
+  Executed: 13
   Pending: 0
 `
 

--- a/test/db/db_test.go
+++ b/test/db/db_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/webhookx-io/webhookx/db"
 	"github.com/webhookx-io/webhookx/db/entities"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/test/helper"
 	"github.com/webhookx-io/webhookx/test/helper/factory"
-	"github.com/webhookx-io/webhookx/utils"
 )
 
 var _ = Describe("DB", Ordered, func() {
@@ -22,9 +22,9 @@ var _ = Describe("DB", Ordered, func() {
 				db = helper.InitDB(true, nil)
 			})
 			It("BatchInsertIgnoreConflict", func() {
-				id1 := utils.KSUID()
-				id2 := utils.KSUID()
-				id3 := utils.KSUID()
+				id1 := uid.Generate(uid.EventPrefix)
+				id2 := uid.Generate(uid.EventPrefix)
+				id3 := uid.Generate(uid.EventPrefix)
 				err := db.Events.Insert(context.TODO(), factory.Event(func(o *entities.Event) { o.ID = id1 }))
 				assert.Nil(GinkgoT(), err)
 				ids, err := db.Events.BatchInsertIgnoreConflict(context.TODO(), []*entities.Event{
@@ -36,6 +36,7 @@ var _ = Describe("DB", Ordered, func() {
 				assert.Equal(GinkgoT(), id2, ids[0])
 				assert.Equal(GinkgoT(), id3, ids[1])
 			})
+
 		})
 	})
 })

--- a/test/delivery/delivery_test.go
+++ b/test/delivery/delivery_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/webhookx-io/webhookx"
 	"github.com/webhookx-io/webhookx/constants"
 	"github.com/webhookx-io/webhookx/db/dao"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/test/helper/factory"
 
 	"github.com/go-resty/resty/v2"
@@ -34,7 +35,7 @@ var _ = Describe("delivery", Ordered, func() {
 			Sources:   []*entities.Source{factory.Source()},
 		}
 		entitiesConfig.Plugins = []*entities.Plugin{{
-			ID:         utils.KSUID(),
+			ID:         uid.Generate(uid.PluginPrefix),
 			EndpointId: new(entitiesConfig.Endpoints[0].ID),
 			Name:       "webhookx-signature",
 			Enabled:    true,

--- a/test/helper/factory/factory.go
+++ b/test/helper/factory/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/openapi"
 	"github.com/webhookx-io/webhookx/pkg/plugin"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/utils"
 )
 
@@ -31,7 +32,7 @@ func defaultEndpoint() entities.Endpoint {
 	var entity entities.Endpoint
 	SetDefault(entities.LookupSchema("Endpoint"), &entity)
 
-	entity.ID = utils.KSUID()
+	entity.ID = uid.Generate(uid.EndpointPrefix)
 	entity.Request = entities.RequestConfig{
 		URL:    "http://localhost:9999/anything",
 		Method: "POST",
@@ -70,7 +71,7 @@ func defaultSource() entities.Source {
 	var entity entities.Source
 	SetDefault(entities.LookupSchema("Source"), &entity)
 
-	entity.ID = utils.KSUID()
+	entity.ID = uid.Generate(uid.SourcePrefix)
 	entity.Type = "http"
 	entity.Config.HTTP.Path = "/"
 	entity.Config.HTTP.Methods = []string{"POST"}
@@ -106,7 +107,7 @@ func defaultPlugin() entities.Plugin {
 	var entity entities.Plugin
 	SetDefault(entities.LookupSchema("Plugin"), &entity)
 
-	entity.ID = utils.KSUID()
+	entity.ID = uid.Generate(uid.PluginPrefix)
 	entity.Config = make(map[string]interface{})
 
 	return entity
@@ -145,7 +146,7 @@ func defaultEvent() entities.Event {
 	var entity entities.Event
 	defaults.Set(&entity)
 
-	entity.ID = utils.KSUID()
+	entity.ID = uid.Generate(uid.EventPrefix)
 	entity.EventType = "foo.bar"
 	entity.Data = []byte("{}")
 
@@ -174,7 +175,7 @@ func defaultWorkspace() entities.Workspace {
 	var entity entities.Workspace
 	SetDefault(entities.LookupSchema("Workspace"), &entity)
 
-	entity.ID = utils.KSUID()
+	entity.ID = uid.Generate(uid.WorkspacePrefix)
 
 	return entity
 }

--- a/test/worker/requeue_test.go
+++ b/test/worker/requeue_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/webhookx-io/webhookx/db/entities"
 	"github.com/webhookx-io/webhookx/pkg/metrics"
 	"github.com/webhookx-io/webhookx/pkg/ratelimiter"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/services"
 	"github.com/webhookx-io/webhookx/services/schedule"
 	"github.com/webhookx-io/webhookx/services/task"
@@ -74,7 +75,7 @@ var _ = Describe("processRequeue", Ordered, func() {
 			assert.NoError(GinkgoT(), db.Events.Insert(context.TODO(), event))
 
 			attempt := entities.Attempt{
-				ID:            utils.KSUID(),
+				ID:            uid.Generate(uid.AttemptPrefix),
 				EventId:       event.ID,
 				EndpointId:    endpoint.ID,
 				Status:        entities.AttemptStatusInit,

--- a/utils/uid.go
+++ b/utils/uid.go
@@ -1,7 +1,0 @@
-package utils
-
-import "github.com/segmentio/ksuid"
-
-func KSUID() string {
-	return ksuid.New().String()
-}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -25,6 +25,7 @@ import (
 	"github.com/webhookx-io/webhookx/pkg/taskqueue"
 	"github.com/webhookx-io/webhookx/pkg/tracing"
 	"github.com/webhookx-io/webhookx/pkg/types"
+	"github.com/webhookx-io/webhookx/pkg/uid"
 	"github.com/webhookx-io/webhookx/plugins"
 	"github.com/webhookx-io/webhookx/services"
 	"github.com/webhookx-io/webhookx/services/distributed"
@@ -491,7 +492,7 @@ func (w *Worker) handleTask(ctx context.Context, task *taskqueue.TaskMessage) er
 
 	delay := endpoint.Retry.Config.Attempts[data.Attempt]
 	nextAttempt := &entities.Attempt{
-		ID:            utils.KSUID(),
+		ID:            uid.Generate(uid.AttemptPrefix),
 		EventId:       data.EventID,
 		EndpointId:    endpoint.ID,
 		Status:        entities.AttemptStatusInit,


### PR DESCRIPTION
### Summary

KSUID (K-Sortable Unique IDentifier) consists of a 32-bit timestamp and a 128-bit random payload. The timestamp only provides second precision, which can have severe Database page splitting during high-concurrency insertion.

This PR uses TypeID (a variant of UUIDv7) as entity IDs to mitigate page splitting and improve insertion performance.


References
- KSUID https://www.twilio.com/en-us/blog/developers/a-brief-history-of-the-uuid