### PR TITLE
fix(metrics): pre-initialize counters to 0 at startup

### DIFF
--- a/pkg/metrics/opentelemetry.go
+++ b/pkg/metrics/opentelemetry.go
@@ -102,9 +102,20 @@ func SetupOpentelemetry(attributes map[string]string, cfg modules.OpentelemetryM
 	metrics.EventPersistCounter = NewCounter(meter, prefix+"event.persisted", "")
 	metrics.EventPendingGauge = NewGauge(meter, prefix+"event.pending", "")
 
+	initialize(metrics)
+
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) { zap.S().Error(err) }))
 
 	return nil
+}
+
+func initialize(metrics *Metrics) {
+	// pre-initialize known counters to 0
+	metrics.ProxyRequestCounter.Add(0)
+	metrics.AttemptTotalCounter.Add(0)
+	metrics.AttemptFailedCounter.Add(0)
+	metrics.EventTotalCounter.Add(0)
+	metrics.EventPersistCounter.Add(0)
 }
 
 func StopOpentelemetry(ctx context.Context) error {

--- a/test/metrics/opentelemetry_test.go
+++ b/test/metrics/opentelemetry_test.go
@@ -56,6 +56,53 @@ var _ = Describe("opentelemetry", Ordered, func() {
 				app.Stop()
 			})
 
+			It("known counters should be initialized to zero before the first delivery", func() {
+				n, err := helper.FileCountLine(helper.OtelCollectorMetricsFile)
+				assert.NoError(GinkgoT(), err)
+				n++
+
+				expected := []string{
+					"webhookx.request.total",
+					"webhookx.attempt.total",
+					"webhookx.attempt.failed",
+					"webhookx.event.total",
+					"webhookx.event.persisted",
+				}
+
+				assert.Eventually(GinkgoT(), func() bool {
+					line, err := helper.FileLine(helper.OtelCollectorMetricsFile, n)
+					if err != nil || line == "" {
+						return false
+					}
+					n++
+
+					var req ExportRequest
+					if err := json.Unmarshal([]byte(line), &req); err != nil {
+						return false
+					}
+
+					values := make(map[string]float64)
+					for _, resourceMetrics := range req.ResourceMetrics {
+						for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+							for _, metric := range scopeMetrics.Metrics {
+								if metric.Sum == nil || len(metric.Sum.DataPoints) != 1 {
+									continue
+								}
+								values[metric.Name] = metric.Sum.DataPoints[0].AsDouble
+							}
+						}
+					}
+
+					for _, name := range expected {
+						value, ok := values[name]
+						if !ok || value != 0 {
+							return false
+						}
+					}
+					return true
+				}, time.Second*40, time.Second)
+			})
+
 			It("sanity", func() {
 				n, err := helper.FileCountLine(helper.OtelCollectorMetricsFile)
 				assert.Nil(GinkgoT(), err)

--- a/test/metrics/types.go
+++ b/test/metrics/types.go
@@ -1,9 +1,6 @@
 package metrics
 
-import (
-	"go.opentelemetry.io/otel/sdk/instrumentation"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-)
+import "go.opentelemetry.io/otel/sdk/instrumentation"
 
 type ResourceMetrics struct {
 	Resource     Resource       `json:"resource,omitempty"`
@@ -25,10 +22,18 @@ type ScopeMetrics struct {
 }
 
 type Metrics struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description"`
-	Unit        string                 `json:"unit"`
-	Data        metricdata.Aggregation `json:"data"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Unit        string `json:"unit"`
+	Sum         *Sum   `json:"sum"`
+}
+
+type Sum struct {
+	DataPoints []NumberDataPoint `json:"dataPoints"`
+}
+
+type NumberDataPoint struct {
+	AsDouble float64 `json:"asDouble"`
 }
 
 type ExportRequest struct {


### PR DESCRIPTION
### Summary

This PR pre-initialize known counters to `0`, so tooling can distinguish healthy / no failures yet. 

Known counters are list as below:

```
webhookx.request.total
webhookx.attempt.total
webhookx.attempt.failed
webhookx.event.total
webhookx.event.persisted
```

See https://github.com/webhookx-io/webhookx/issues/348